### PR TITLE
feat: Add create-pr skill for Sentry PR conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Copy the `skills/` directory to your agent's skills location, or reference the S
 |-------|-------------|
 | [code-review](plugins/sentry-skills/skills/code-review/SKILL.md) | Sentry code review guidelines and checklist |
 | [commit](plugins/sentry-skills/skills/commit/SKILL.md) | Sentry commit message conventions |
+| [create-pr](plugins/sentry-skills/skills/create-pr/SKILL.md) | Create pull requests following Sentry conventions |
 | [deslop](plugins/sentry-skills/skills/deslop/SKILL.md) | Remove AI-generated code slop from branch changes |
 | [find-bugs](plugins/sentry-skills/skills/find-bugs/SKILL.md) | Find bugs and security vulnerabilities in branch changes |
 

--- a/plugins/sentry-skills/skills/create-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/create-pr/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: create-pr
+description: Create pull requests following Sentry conventions. Use when opening PRs, writing PR descriptions, or preparing changes for review. Follows Sentry's code review guidelines.
+---
+
+# Create Pull Request
+
+Create pull requests following Sentry's engineering practices.
+
+**Requires**: GitHub CLI (`gh`) authenticated and available.
+
+## Process
+
+### Step 1: Verify Branch State
+
+```bash
+# Check current branch and status
+git status
+git log main..HEAD --oneline
+```
+
+Ensure:
+- All changes are committed
+- Branch is up to date with remote
+- Changes are rebased on main if needed
+
+### Step 2: Analyze Changes
+
+Review what will be included in the PR:
+
+```bash
+# See all commits that will be in the PR
+git log main..HEAD
+
+# See the full diff
+git diff main...HEAD
+```
+
+Understand the scope and purpose of all changes before writing the description.
+
+### Step 3: Write the PR Description
+
+Follow this structure:
+
+```markdown
+<brief description of what the PR does>
+
+<why these changes are being made - the motivation>
+
+<alternative approaches considered, if any>
+
+<any additional context reviewers need>
+```
+
+**Do NOT include:**
+- "Test plan" sections
+- Checkbox lists of testing steps
+- Redundant summaries of the diff
+
+**Do include:**
+- Clear explanation of what and why
+- Links to relevant issues or tickets
+- Context that isn't obvious from the code
+- Notes on specific areas that need careful review
+
+### Step 4: Create the PR
+
+```bash
+gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+<description body here>
+EOF
+)"
+```
+
+**Title format** follows commit conventions:
+- `feat(scope): Add new feature`
+- `fix(scope): Fix the bug`
+- `ref: Refactor something`
+
+### Step 5: Add Reviewers (if known)
+
+```bash
+# Request review from specific people
+gh pr edit --add-reviewer username1,username2
+
+# Or request from a team
+gh pr edit --add-reviewer @getsentry/team-name
+```
+
+Limit to 1-3 reviewers to maintain clear ownership.
+
+## PR Description Examples
+
+### Feature PR
+
+```markdown
+Add Slack thread replies for alert notifications
+
+When an alert is updated or resolved, we now post a reply to the original
+Slack thread instead of creating a new message. This keeps related
+notifications grouped and reduces channel noise.
+
+Previously considered posting edits to the original message, but threading
+better preserves the timeline of events and works when the original message
+is older than Slack's edit window.
+
+Refs SENTRY-1234
+```
+
+### Bug Fix PR
+
+```markdown
+Handle null response in user API endpoint
+
+The user endpoint could return null for soft-deleted accounts, causing
+dashboard crashes when accessing user properties. This adds a null check
+and returns a proper 404 response.
+
+Found while investigating SENTRY-5678.
+
+Fixes SENTRY-5678
+```
+
+### Refactor PR
+
+```markdown
+Extract validation logic to shared module
+
+Moves duplicate validation code from the alerts, issues, and projects
+endpoints into a shared validator class. No behavior change.
+
+This prepares for adding new validation rules in SENTRY-9999 without
+duplicating logic across endpoints.
+```
+
+## Issue References
+
+Reference issues in the PR body:
+
+| Syntax | Effect |
+|--------|--------|
+| `Fixes #1234` | Closes GitHub issue on merge |
+| `Fixes SENTRY-1234` | Closes Sentry issue |
+| `Refs GH-1234` | Links without closing |
+| `Refs LINEAR-ABC-123` | Links Linear issue |
+
+## Guidelines
+
+- **One PR per feature/fix** - Don't bundle unrelated changes
+- **Keep PRs reviewable** - Smaller PRs get faster, better reviews
+- **Explain the why** - Code shows what; description explains why
+- **Mark WIP early** - Use draft PRs for early feedback
+
+## References
+
+- [Sentry Code Review Guidelines](https://develop.sentry.dev/engineering-practices/code-review/)
+- [Sentry Commit Messages](https://develop.sentry.dev/engineering-practices/commit-messages/)


### PR DESCRIPTION
Add a skill that guides PR creation following Sentry's engineering practices.

The existing commit skill covers commit message formatting, but there was no
guidance for PR descriptions. This fills that gap based on Sentry's code review
documentation at develop.sentry.dev.

Key conventions captured:
- PR description structure: what, why, alternatives considered, context
- Title format following commit conventions (type(scope): description)
- Issue reference syntax (Fixes/Refs for GitHub, Jira, Linear)
- Guidelines on keeping PRs focused and reviewable
- Reviewer assignment best practices

Notably, Sentry does NOT use "Test plan" sections in PRs, so this skill
explicitly excludes that pattern.

Refs https://develop.sentry.dev/engineering-practices/code-review/

🤖 Generated with [Claude Code](https://claude.com/claude-code)