### PR TITLE
fix(claude-settings-audit): Improve recommendation accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Each skill is a directory containing a `SKILL.md` file with YAML frontmatter (`n
 2. Add YAML frontmatter (see below)
 3. Write clear instructions in markdown
 4. Update `README.md` to include the new skill in the Available Skills table
+5. Update the skills allowlist in `plugins/sentry-skills/skills/claude-settings-audit/SKILL.md`
 
 ### Frontmatter
 

--- a/plugins/sentry-skills/skills/claude-settings-audit/SKILL.md
+++ b/plugins/sentry-skills/skills/claude-settings-audit/SKILL.md
@@ -135,6 +135,22 @@ Only include commands for tools actually detected in the project.
 | `*.tf` files | `terraform --version`, `terraform providers`, `terraform state list` |
 | `Makefile` | `make --version`, `make -n` |
 
+### Skills (for Sentry Projects)
+
+If this is a Sentry project (or sentry-skills plugin is installed), include:
+
+```json
+[
+  "Skill(sentry-skills:commit)",
+  "Skill(sentry-skills:create-pr)",
+  "Skill(sentry-skills:code-review)",
+  "Skill(sentry-skills:find-bugs)",
+  "Skill(sentry-skills:deslop)",
+  "Skill(sentry-skills:iterate-pr)",
+  "Skill(sentry-skills:claude-settings-audit)"
+]
+```
+
 ### WebFetch Domains
 
 #### Always Include (Sentry Projects)


### PR DESCRIPTION
Improve the claude-settings-audit skill to generate more accurate and
conservative recommendations.

The skill was previously suggesting all ecosystem tools regardless of
what the project actually uses. For example, a pnpm project would get
suggestions for npm, yarn, AND pnpm commands. This led to bloated
allow lists with tools that might not even be installed.

Changes:
- Add explicit rules to never include user-specific absolute paths
  (e.g., `/home/user/scripts/foo`)
- Add rules to never include custom project scripts that may have
  side effects
- Reorganize package manager detection to only suggest the tool
  actually used (detected via lock files)
- Add "Package Manager Rules" table showing exactly which commands
  to include/exclude based on what lock file is present