### PR TITLE
fix(iterate-pr): Use explicit branch name in git push command

### DIFF
--- a/plugins/sentry-skills/skills/iterate-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/iterate-pr/SKILL.md
@@ -90,7 +90,7 @@ Make minimal, targeted code changes. Only fix what is actually broken.
 ```bash
 git add -A
 git commit -m "fix: <descriptive message of what was fixed>"
-git push
+git push origin $(git branch --show-current)
 ```
 
 ### Step 8: Wait for CI


### PR DESCRIPTION
Use explicit remote and branch name when pushing in the iterate-pr skill.

A bare `git push` may push multiple branches depending on the user's git
`push.default` configuration. By explicitly specifying `origin` and the
current branch name, we ensure only the working branch is pushed.