### PR TITLE
chore: Add sentry-skills to project settings allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,15 @@
       "Bash(gh run list:*)",
       "Bash(gh run logs:*)",
       "Bash(gh repo view:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+
+      "Skill(sentry-skills:commit)",
+      "Skill(sentry-skills:create-pr)",
+      "Skill(sentry-skills:code-review)",
+      "Skill(sentry-skills:find-bugs)",
+      "Skill(sentry-skills:deslop)",
+      "Skill(sentry-skills:iterate-pr)",
+      "Skill(sentry-skills:claude-settings-audit)"
     ],
     "deny": []
   },


### PR DESCRIPTION
Pre-approve all sentry-skills for use in this repository.

When developing the plugin itself, it's helpful to have the skills pre-approved
so they can be invoked without manual confirmation. This adds all current
sentry-skills to the project's Claude Code settings allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)