### PR TITLE
feat(skills): Add prerequisite checks to commit and create-pr skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Each skill is a directory containing a `SKILL.md` file with YAML frontmatter (`n
 3. Write clear instructions in markdown
 4. Update `README.md` to include the new skill in the Available Skills table
 5. Update the skills allowlist in `plugins/sentry-skills/skills/claude-settings-audit/SKILL.md`
+6. Add the skill to `.claude/settings.json` in the `permissions.allow` array as `Skill(sentry-skills:<skill-name>)`
 
 ### Frontmatter
 

--- a/plugins/sentry-skills/skills/commit/SKILL.md
+++ b/plugins/sentry-skills/skills/commit/SKILL.md
@@ -7,6 +7,24 @@ description: Create commit messages following Sentry conventions. Use when commi
 
 Follow these conventions when creating commits for Sentry projects.
 
+## Prerequisites
+
+Before committing, ensure you're working on a feature branch, not the main branch.
+
+```bash
+# Check current branch
+git branch --show-current
+```
+
+If you're on `main` or `master`, create a new branch first:
+
+```bash
+# Create and switch to a new branch
+git checkout -b <type>/<short-description>
+```
+
+Branch naming should follow the pattern: `<type>/<short-description>` where type matches the commit type (e.g., `feat/add-user-auth`, `fix/null-pointer-error`, `ref/extract-validation`).
+
 ## Format
 
 ```

--- a/plugins/sentry-skills/skills/create-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/create-pr/SKILL.md
@@ -9,6 +9,17 @@ Create pull requests following Sentry's engineering practices.
 
 **Requires**: GitHub CLI (`gh`) authenticated and available.
 
+## Prerequisites
+
+Before creating a PR, ensure all changes are committed. If there are uncommitted changes, run the `sentry-skills:commit` skill first to commit them properly.
+
+```bash
+# Check for uncommitted changes
+git status --porcelain
+```
+
+If the output shows any uncommitted changes (modified, added, or untracked files that should be included), invoke the `sentry-skills:commit` skill before proceeding.
+
 ## Process
 
 ### Step 1: Verify Branch State


### PR DESCRIPTION
Add workflow prerequisites to enforce proper git hygiene when using the commit and create-pr skills.

The commit skill now checks if you're on main/master and prompts to create a feature branch first,
following the `<type>/<short-description>` naming convention. The create-pr skill now checks for
uncommitted changes and directs users to run the commit skill first.

Also adds a missing step to AGENTS.md: when creating new skills, they should be added to the
`.claude/settings.json` allowlist.

Note: The Agent Skills spec doesn't support formal skill dependencies, so these are implemented
as documented prerequisites in the skill instructions.