### PR TITLE
fix(claude-settings-audit): Use correct Sentry MCP HTTP configuration

### DIFF
--- a/plugins/sentry-skills/skills/claude-settings-audit/SKILL.md
+++ b/plugins/sentry-skills/skills/claude-settings-audit/SKILL.md
@@ -191,16 +191,13 @@ cat .mcp.json 2>/dev/null || echo "No existing .mcp.json"
 
 #### Sentry MCP (if Sentry SDK detected)
 
-Add to `.mcp.json`:
+Add to `.mcp.json` (replace `{org-slug}` and `{project-slug}` with your Sentry organization and project slugs):
 ```json
 {
   "mcpServers": {
     "sentry": {
-      "command": "uvx",
-      "args": ["mcp-server-sentry"],
-      "env": {
-        "SENTRY_AUTH_TOKEN": "${SENTRY_AUTH_TOKEN}"
-      }
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp/{org-slug}/{project-slug}"
     }
   }
 }


### PR DESCRIPTION
The claude-settings-audit skill was recommending an incorrect MCP configuration
for Sentry. It suggested using a command-based MCP server with `uvx mcp-server-sentry`,
but Sentry MCP is actually a hosted service using streaming HTTP.

Updated to use the correct URL-based configuration format with `type: "http"` pointing
to `https://mcp.sentry.dev/mcp/{org-slug}/{project-slug}`.