### PR TITLE
feat(create-pr): Add PR template support

### DIFF
--- a/plugins/sentry-skills/skills/create-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/create-pr/SKILL.md
@@ -54,7 +54,14 @@ Understand the scope and purpose of all changes before writing the description.
 
 ### Step 3: Write the PR Description
 
-Follow this structure:
+First, check if the repository has a PR template:
+
+```bash
+# Fetch PR template from GitHub
+gh repo view --json pullRequestTemplates --jq '.pullRequestTemplates[0].body'
+```
+
+If a PR template exists, follow its structure and fill in all required sections. Otherwise, follow this structure:
 
 ```markdown
 <brief description of what the PR does>


### PR DESCRIPTION
Update the create-pr skill to fetch and respect the repository's PR template before writing the PR description.

Previously, the skill would always use its default structure for PR descriptions. Now it first checks for a PR template using `gh repo view --json pullRequestTemplates` and instructs the agent to follow that template's structure when one exists.

This ensures PRs created by the agent match the expected format for each repository and fill in all required sections defined by the repo maintainers.