### PR TITLE
ref(create-pr): Extract PR template retrieval to script

### DIFF
--- a/plugins/sentry-skills/skills/create-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/create-pr/SKILL.md
@@ -54,24 +54,13 @@ Understand the scope and purpose of all changes before writing the description.
 
 ### Step 3: Write the PR Description
 
-First, check if the repository has a PR template:
+Get the PR template for this repository:
 
 ```bash
-# Fetch PR template from GitHub
-gh repo view --json pullRequestTemplates --jq '.pullRequestTemplates[0].body'
+bash "${CLAUDE_PLUGIN_ROOT}/skills/create-pr/scripts/get-pr-template.sh"
 ```
 
-If a PR template exists, follow its structure and fill in all required sections. Otherwise, follow this structure:
-
-```markdown
-<brief description of what the PR does>
-
-<why these changes are being made - the motivation>
-
-<alternative approaches considered, if any>
-
-<any additional context reviewers need>
-```
+Follow the template structure and fill in all required sections.
 
 **Do NOT include:**
 - "Test plan" sections

--- a/plugins/sentry-skills/skills/create-pr/scripts/get-pr-template.sh
+++ b/plugins/sentry-skills/skills/create-pr/scripts/get-pr-template.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Fetches PR template from GitHub or outputs the default template
+
+template=$(gh repo view --json pullRequestTemplates --jq '.pullRequestTemplates[0].body' 2>/dev/null)
+
+if [ -n "$template" ]; then
+    echo "$template"
+else
+    cat <<'EOF'
+<brief description of what the PR does>
+
+<why these changes are being made - the motivation>
+
+<alternative approaches considered, if any>
+
+<any additional context reviewers need>
+EOF
+fi


### PR DESCRIPTION
Move the conditional PR template logic from SKILL.md instructions into a deterministic bash script.

Previously, the skill instructed the LLM to run `gh repo view --json pullRequestTemplates` and interpret whether a template exists. This relied on the LLM correctly handling empty/null output.

Now, a script handles this logic deterministically:
- Fetches the repo's PR template via `gh`
- Falls back to the default template if none exists
- Outputs the appropriate template for the LLM to follow

This makes the template retrieval reliable and testable.

---

Stacked on #18

🤖 Generated with [Claude Code](https://claude.ai/claude-code)