### PR TITLE
fix(create-pr): Replace broken gh pr edit with gh api

### DIFF
--- a/plugins/sentry-skills/skills/create-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/create-pr/SKILL.md
@@ -166,10 +166,10 @@ If you need to update a PR after creation, use `gh api` instead of `gh pr edit`:
 
 ```bash
 # Update PR description
-gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f body='$(cat <<'EOF'
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f body="$(cat <<'EOF'
 Updated description here
 EOF
-)'
+)"
 
 # Update PR title
 gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f title='new: Title here'


### PR DESCRIPTION
The `gh pr edit` command fails with a GraphQL error about GitHub Projects (classic) deprecation, even when editing unrelated fields like title or body.

This updates the create-pr skill to use `gh api` PATCH requests instead, which directly call the REST API and bypass this issue entirely.

Changes:
- Remove Step 5 "Add Reviewers" section that used `gh pr edit --add-reviewer`
- Add new "Editing Existing PRs" section with working `gh api` commands for updating PR title/body