### PR TITLE
fix(create-pr): Create draft PRs and skip repo templates

### DIFF
--- a/plugins/sentry-skills/skills/create-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/create-pr/SKILL.md
@@ -54,14 +54,7 @@ Understand the scope and purpose of all changes before writing the description.
 
 ### Step 3: Write the PR Description
 
-First, check if the repository has a PR template:
-
-```bash
-# Fetch PR template from GitHub
-gh repo view --json pullRequestTemplates --jq '.pullRequestTemplates[0].body'
-```
-
-If a PR template exists, follow its structure and fill in all required sections. Otherwise, follow this structure:
+Use this structure for PR descriptions (ignoring any repository PR templates):
 
 ```markdown
 <brief description of what the PR does>
@@ -87,7 +80,7 @@ If a PR template exists, follow its structure and fill in all required sections.
 ### Step 4: Create the PR
 
 ```bash
-gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+gh pr create --draft --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
 <description body here>
 EOF
 )"


### PR DESCRIPTION
Create PRs in draft state by default, giving authors time to review before
requesting feedback. Also skip fetching repository PR templates in favor of
the skill's own consistent format.

Changes:
- Add `--draft` flag to `gh pr create` command
- Remove PR template fetching step that instructed users to follow repo templates
- Simplify description instructions to use the skill's format directly