### PR TITLE
fix(iterate-pr): Handle workflow field as string from gh CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,10 @@ license: LICENSE
 Instructions for the agent.
 ```
 
+## Skill Design Guidelines
+
+When writing skills that include Python scripts, always instruct the agent to use `uv run <script>` instead of `python <script>` or `python3 <script>`.
+
 ## References
 
 - [Agent Skills Spec](https://agentskills.io/specification)

--- a/plugins/sentry-skills/skills/iterate-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/iterate-pr/SKILL.md
@@ -16,7 +16,7 @@ Continuously iterate on the current branch until all CI checks pass and review f
 Fetches CI check status and extracts failure snippets from logs.
 
 ```bash
-python scripts/fetch_pr_checks.py [--pr NUMBER]
+uv run scripts/fetch_pr_checks.py [--pr NUMBER]
 ```
 
 Returns JSON:
@@ -36,7 +36,7 @@ Returns JSON:
 Fetches and categorizes PR review feedback using the [LOGAF scale](https://develop.sentry.dev/engineering-practices/code-review/#logaf-scale).
 
 ```bash
-python scripts/fetch_pr_feedback.py [--pr NUMBER]
+uv run scripts/fetch_pr_feedback.py [--pr NUMBER]
 ```
 
 Returns JSON with feedback categorized as:

--- a/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_checks.py
+++ b/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_checks.py
@@ -170,7 +170,7 @@ def main():
             "name": check.get("name", "unknown"),
             "status": check.get("bucket", check.get("state", "unknown")),
             "link": check.get("link", ""),
-            "workflow": check.get("workflow", {}).get("name", ""),
+            "workflow": check.get("workflow", ""),
         }
 
         # For failures, try to get log snippet


### PR DESCRIPTION
Fix AttributeError when accessing workflow field from `gh pr checks --json`.

The `gh` CLI returns the `workflow` field as a string (the workflow name directly),
not as an object with a `name` property. The previous code assumed it was a dict
and called `.get("name")` on a string, causing:

```
AttributeError: 'str' object has no attribute 'get'
```

Also updates the skill documentation to use `uv run <script>` instead of
`python <script>`, and adds a guideline to AGENTS.md for consistent script
invocation across all skills.