### PR TITLE
fix(iterate-pr): Add PEP 723 requires-python metadata to scripts

### DIFF
--- a/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_checks.py
+++ b/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_checks.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# ///
 """
 Fetch PR CI checks and extract relevant failure snippets.
 

--- a/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_feedback.py
+++ b/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_feedback.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# ///
 """
 Fetch and categorize PR review feedback.
 


### PR DESCRIPTION
Add PEP 723 inline script metadata to specify `requires-python = ">=3.9"` for the iterate-pr helper scripts.

Without explicit Python version metadata, `uv run` defaults to requiring Python 3.13+, causing failures on systems that don't have Python 3.13 installed. The scripts were already written for Python 3.9 compatibility (using `from __future__ import annotations`), but uv had no way to know this.

This was discovered when a user ran the skill and got:
```
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.13`.
```
followed by a script failure.