### PR TITLE
fix(skills): Fix broken frontmatter and remove hardcoded model overrides

### DIFF
--- a/plugins/sentry-skills/skills/code-simplifier/SKILL.md
+++ b/plugins/sentry-skills/skills/code-simplifier/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Use when asked to "simplify code", "clean up code", "refactor for clarity", "improve readability", or review recently modified code for elegance. Focuses on project-specific best practices.
-model: opus
 ---
 
 <!--

--- a/plugins/sentry-skills/skills/django-access-review/SKILL.md
+++ b/plugins/sentry-skills/skills/django-access-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: django-access-review
-description: Django access control and IDOR security review. Use when reviewing Django views, DRF viewsets, ORM queries, or any Python/Django code handling user authorization. Trigger keywords: "IDOR", "access control", "authorization", "Django permissions", "object permissions", "tenant isolation", "broken access".
-model: sonnet
+description: 'Django access control and IDOR security review. Use when reviewing Django views, DRF viewsets, ORM queries, or any Python/Django code handling user authorization. Trigger keywords: "IDOR", "access control", "authorization", "Django permissions", "object permissions", "tenant isolation", "broken access".'
 allowed-tools: Read Grep Glob Bash Task
 license: LICENSE
 ---

--- a/plugins/sentry-skills/skills/django-perf-review/SKILL.md
+++ b/plugins/sentry-skills/skills/django-perf-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: django-perf-review
 description: Django performance code review. Use when asked to "review Django performance", "find N+1 queries", "optimize Django", "check queryset performance", "database performance", "Django ORM issues", or audit Django code for performance problems.
-model: sonnet
 allowed-tools: Read Grep Glob Bash Task
 license: LICENSE
 ---

--- a/plugins/sentry-skills/skills/security-review/SKILL.md
+++ b/plugins/sentry-skills/skills/security-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: security-review
 description: Security code review for vulnerabilities. Use when asked to "security review", "find vulnerabilities", "check for security issues", "audit security", "OWASP review", or review code for injection, XSS, authentication, authorization, cryptography issues. Provides systematic review with confidence-based reporting.
-model: sonnet
 allowed-tools: Read Grep Glob Bash Task
 license: LICENSE
 ---


### PR DESCRIPTION
Fix two issues across skill frontmatter:

**Broken YAML frontmatter in `django-access-review`**: The `description` field
contained unescaped colons (`Trigger keywords: "IDOR", "access control"...`)
which caused YAML parsers to fail. Wrapped the value in single quotes.

**Hardcoded model overrides**: Removed `model:` from `django-access-review`
(sonnet), `django-perf-review` (sonnet), `security-review` (sonnet), and
`code-simplifier` (opus). Skills should use the user's default model rather
than forcing a specific one.

Found via the new `skill-scanner` skill (#40).