### PR TITLE
feat(skills): Strengthen commit and create-pr skill descriptions

### DIFF
--- a/plugins/sentry-skills/skills/commit/SKILL.md
+++ b/plugins/sentry-skills/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Create commit messages following Sentry conventions. Use when committing code changes, writing commit messages, or formatting git history. Follows conventional commits with Sentry-specific issue references.
+description: ALWAYS use this skill when committing code changes — never commit directly without it. Creates commits following Sentry conventions with proper conventional commit format and issue references. Trigger on any commit, git commit, save changes, or commit message task.
 ---
 
 # Sentry Commit Messages
@@ -9,14 +9,13 @@ Follow these conventions when creating commits for Sentry projects.
 
 ## Prerequisites
 
-Before committing, ensure you're working on a feature branch, not the main branch.
+Before committing, always check the current branch:
 
 ```bash
-# Check current branch
 git branch --show-current
 ```
 
-If you're on `main` or `master`, create a new branch first:
+**If you're on `main` or `master`, you MUST create a feature branch first** — unless the user explicitly asked to commit to main. Do not ask for confirmation; default to creating the branch.
 
 ```bash
 # Create and switch to a new branch

--- a/plugins/sentry-skills/skills/create-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: Create pull requests following Sentry conventions. Use when opening PRs, writing PR descriptions, or preparing changes for review. Follows Sentry's code review guidelines.
+description: ALWAYS use this skill when creating pull requests — never create a PR directly without it. Follows Sentry conventions for PR titles, descriptions, and issue references. Trigger on any create PR, open PR, submit PR, make PR, push and create PR, or prepare changes for review task.
 ---
 
 # Create Pull Request


### PR DESCRIPTION
Adds strong steering to the `commit` and `create-pr` skill descriptions so they are always triggered when the agent is committing or creating PRs, rather than only sometimes matching.

Also updates the commit skill's prerequisites to default to creating a feature branch when on main/master, without asking for confirmation — unless the user explicitly asks to commit to main.