### PR TITLE
fix(brand-guidelines): Update dead Sentry Voice Guidelines link

### DIFF
--- a/plugins/sentry-skills/skills/brand-guidelines/SKILL.md
+++ b/plugins/sentry-skills/skills/brand-guidelines/SKILL.md
@@ -164,5 +164,5 @@ Avoid these common mistakes:
 
 ## References
 
-- [Sentry Voice Guidelines](https://develop.sentry.dev/frontend/sentry-voice/)
+- [Sentry Voice Guidelines](https://github.com/getsentry/sentry/blob/master/static/app/components/core/principles/content-and-voice/content-and-voice.mdx)
 - [Sentry Frontend Handbook](https://develop.sentry.dev/frontend/)


### PR DESCRIPTION
## Summary
- The [Sentry Voice Guidelines](https://develop.sentry.dev/frontend/sentry-voice/) link in `brand-guidelines/SKILL.md` returns a 404
- The content has moved to the sentry repo's design system: `static/app/components/core/principles/content-and-voice/content-and-voice.mdx`
- Updated the reference to point to the [source file on GitHub](https://github.com/getsentry/sentry/blob/master/static/app/components/core/principles/content-and-voice/content-and-voice.mdx)

## Test plan
- [x] Verified old link returns 404
- [x] Verified new link resolves correctly