### PR TITLE
fix(iterate-pr): Reorder workflow to catch late review bot feedback

### DIFF
--- a/plugins/sentry-skills/skills/agents-md/SKILL.md
+++ b/plugins/sentry-skills/skills/agents-md/SKILL.md
@@ -30,6 +30,7 @@ Read each skill's frontmatter to understand when to reference it.
 - **Reference, don't duplicate** - Point to skills: "Use `db-migrate` skill. See `.claude/skills/db-migrate/SKILL.md`"
 - **No filler** - No intros, conclusions, or pleasantries
 - **Trust capabilities** - Omit obvious context
+- **Skill updates** - ALWAYS use `/skill-creator` when creating or updating skills
 
 ## Required Sections
 


### PR DESCRIPTION
The iterate-pr skill had a race condition: after CI completes, review bot
feedback (Sentry, Warden, Bugbot, etc.) may not yet be visible. The
workflow checked CI first, then feedback once — but bots often post
seconds after CI checks turn green, causing the skill to declare success
before seeing actionable feedback.

**iterate-pr changes:**
- Gather and address existing review feedback *before* checking CI, so
  comments are handled early
- Add a post-CI delayed re-check: `sleep 10` then re-fetch feedback to
  catch late-arriving review bot comments
- Update exit conditions to require the post-CI re-check to be clean

**agents-md change:**
- Add `/skill-creator` rule to Writing Rules: always use it when creating
  or updating skills