### PR TITLE
fix(iterate-pr): Remove invalid --json flag from gh pr checks fallback

### DIFF
--- a/plugins/sentry-skills/skills/iterate-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/iterate-pr/SKILL.md
@@ -146,6 +146,6 @@ Return to step 2 if CI failed or new feedback appeared in step 8.
 ## Fallback
 
 If scripts fail, use `gh` CLI directly:
-- `gh pr checks --json name,state,bucket,link`
+- `gh pr checks name,state,bucket,link`
 - `gh run view <run-id> --log-failed`
 - `gh api repos/{owner}/{repo}/pulls/{number}/comments`


### PR DESCRIPTION
I keep seeing this

<img width="1802" height="200" alt="image" src="https://github.com/user-attachments/assets/12b3ec04-0ee8-4291-8d40-642ed42ef3fc" />


The `gh pr checks` command does not support the `--json` flag, which was
being used in the iterate-pr skill's fallback section. This caused the
field names (`name,state,bucket,link`) to be misinterpreted as a branch
selector argument.

Removes the `--json` flag while keeping the field names as contextual
hints for the LLM about what information to extract from the output.