### PR TITLE
ref(skills): Standardize skill paths to Agent Skills spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ Instructions for the agent.
 
 When writing skills that include Python scripts, always instruct the agent to use `uv run <script>` instead of `python <script>` or `python3 <script>`.
 
+Use skill-root-relative paths for skill files (`scripts/...`, `references/...`, `assets/...`). These references are relative to the skill directory (where `SKILL.md` lives), not the current working directory. When executing commands, resolve them using the skill directory. Do not use `${CLAUDE_SKILL_ROOT}` or hardcoded repository paths.
+
 ## References
 
 - [Agent Skills Spec](https://agentskills.io/specification)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Concrete examples showing expected input/output.
 - Edge cases to handle
 ```
 
+#### Skill Path References
+
+Use skill-root-relative paths for files referenced inside `SKILL.md`.
+These references are relative to the skill directory (the directory containing `SKILL.md`), not the current working directory. When executing commands from elsewhere (for example, repo root), resolve them using the skill directory:
+
+- `scripts/...`
+- `references/...`
+- `assets/...`
+
+Do not use `${CLAUDE_SKILL_ROOT}` or hardcoded repository paths like `plugins/.../skills/...`.
+
 #### Naming Conventions
 
 - **name**: 1-64 characters, lowercase alphanumeric with hyphens only

--- a/plugins/sentry-skills/skills/gh-review-requests/SKILL.md
+++ b/plugins/sentry-skills/skills/gh-review-requests/SKILL.md
@@ -21,13 +21,13 @@ Accept either a team slug (`streaming-platform`) or a display name ("Streaming P
 ## Step 2: Run the Script
 
 ```bash
-uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_review_requests.py --org getsentry --teams <team-slug>
+uv run scripts/fetch_review_requests.py --org getsentry --teams <team-slug>
 ```
 
 To filter by multiple teams, pass a comma-separated list:
 
 ```bash
-uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_review_requests.py --org getsentry --teams <team slugs>
+uv run scripts/fetch_review_requests.py --org getsentry --teams <team slugs>
 ```
 
 ### Script output

--- a/plugins/sentry-skills/skills/iterate-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/iterate-pr/SKILL.md
@@ -9,7 +9,7 @@ Continuously iterate on the current branch until all CI checks pass and review f
 
 **Requires**: GitHub CLI (`gh`) authenticated.
 
-**Important**: All scripts must be run from the repository root directory (where `.git` is located), not from the skill directory. Use the full path to the script via `${CLAUDE_SKILL_ROOT}`.
+**Important**: All scripts must be run from the repository root directory (where `.git` is located), not from the skill directory. Invoke scripts using their absolute paths.
 
 ## Bundled Scripts
 
@@ -18,7 +18,7 @@ Continuously iterate on the current branch until all CI checks pass and review f
 Fetches CI check status and extracts failure snippets from logs.
 
 ```bash
-uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py [--pr NUMBER]
+uv run scripts/fetch_pr_checks.py [--pr NUMBER]
 ```
 
 Returns JSON:
@@ -38,7 +38,7 @@ Returns JSON:
 Fetches and categorizes PR review feedback using the [LOGAF scale](https://develop.sentry.dev/engineering-practices/code-review/#logaf-scale).
 
 ```bash
-uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py [--pr NUMBER]
+uv run scripts/fetch_pr_feedback.py [--pr NUMBER]
 ```
 
 Returns JSON with feedback categorized as:
@@ -62,7 +62,7 @@ Stop if no PR exists for the current branch.
 
 ### 2. Gather Review Feedback
 
-Run `${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py` to get categorized feedback already posted on the PR.
+Run `scripts/fetch_pr_feedback.py` to get categorized feedback already posted on the PR.
 
 ### 3. Handle Feedback by LOGAF Priority
 
@@ -93,7 +93,7 @@ Which would you like to address? (e.g., "1,3" or "all" or "none")
 
 ### 4. Check CI Status
 
-Run `${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py` to get structured failure data.
+Run `scripts/fetch_pr_checks.py` to get structured failure data.
 
 **Wait if pending:** If review bot checks (sentry, warden, cursor, bugbot, seer, codeql) are still running, wait before proceeding—they post actionable feedback that must be evaluated. Informational bots (codecov) are not worth waiting for.
 
@@ -126,7 +126,7 @@ Review bots often post feedback seconds after CI checks complete. Wait briefly, 
 
 ```bash
 sleep 10
-uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py
+uv run scripts/fetch_pr_feedback.py
 ```
 
 Address any new high/medium feedback the same way as step 3. If new feedback requires code changes, return to step 6 to commit and push.

--- a/plugins/sentry-skills/skills/skill-creator/SKILL.md
+++ b/plugins/sentry-skills/skills/skill-creator/SKILL.md
@@ -44,7 +44,7 @@ Gather requirements before writing anything.
 | **With scripts** | `SKILL.md` + `scripts/` | Workflow automation needing Python scripts |
 | **Full** | All of the above | Complex skills with automation and domain knowledge |
 
-Read `${CLAUDE_SKILL_ROOT}/references/design-principles.md` for guidance on keeping skills focused and concise.
+Read `references/design-principles.md` for guidance on keeping skills focused and concise.
 
 ## Step 2: Plan the Skill
 
@@ -64,7 +64,7 @@ Example analysis:
 
 Before writing, study 1-2 existing skills that match the chosen tier. Look for skills in the target repository or plugin to understand local conventions.
 
-Read `${CLAUDE_SKILL_ROOT}/references/skill-patterns.md` for concrete examples of each tier.
+Read `references/skill-patterns.md` for concrete examples of each tier.
 
 Also read `CLAUDE.md` (or `AGENTS.md`) at the repository root for repo-specific conventions that the skill should follow.
 
@@ -93,7 +93,7 @@ description: <what it does>. Use when <trigger phrases>. <key capabilities>.
 - `metadata` — arbitrary key-value mapping for additional metadata
 - `compatibility` — environment requirements (max 500 chars); most skills don't need this
 
-For Claude Code-specific fields (`argument-hint`, `disable-model-invocation`, `context`, etc.), read `${CLAUDE_SKILL_ROOT}/references/claude-code-extensions.md`.
+For Claude Code-specific fields (`argument-hint`, `disable-model-invocation`, `context`, etc.), read `references/claude-code-extensions.md`.
 
 ### Description Guidelines
 
@@ -132,8 +132,8 @@ Write the body in **imperative voice** — these are instructions, not documenta
 5. End with validation criteria or exit conditions
 
 For workflow and output patterns, read:
-- `${CLAUDE_SKILL_ROOT}/references/workflow-patterns.md` — sequential workflows, feedback loops, plan-validate-execute
-- `${CLAUDE_SKILL_ROOT}/references/output-patterns.md` — template, examples, and structured data patterns
+- `references/workflow-patterns.md` — sequential workflows, feedback loops, plan-validate-execute
+- `references/output-patterns.md` — template, examples, and structured data patterns
 
 **Size limits:**
 - Keep SKILL.md under **500 lines** (< 5000 tokens recommended)
@@ -185,7 +185,7 @@ Use for domain knowledge the agent loads conditionally.
 
 Reference from SKILL.md with:
 ```markdown
-Read `${CLAUDE_SKILL_ROOT}/references/topic-a.md` for details on [topic].
+Read `references/topic-a.md` for details on [topic].
 ```
 
 Guidelines:
@@ -207,7 +207,7 @@ Use for workflow automation that benefits from structured Python.
 ```
 
 **Script requirements:**
-- Always use `uv run` to execute: `uv run ${CLAUDE_SKILL_ROOT}/scripts/do_thing.py`
+- Always use `uv run` to execute: `uv run scripts/do_thing.py`
 - Add PEP 723 inline metadata for dependencies:
 
 ```python
@@ -235,7 +235,7 @@ Include a LICENSE file in the skill directory when vendoring content with specif
 Run the validation script to catch issues early:
 
 ```bash
-uv run ${CLAUDE_SKILL_ROOT}/scripts/quick_validate.py <path/to/skill-directory>
+uv run scripts/quick_validate.py <path/to/skill-directory>
 ```
 
 The script checks frontmatter format, required fields, naming rules, and common mistakes. Fix any errors and re-run until validation passes.
@@ -282,14 +282,14 @@ Run through this checklist before finishing:
 - [ ] Any repo-specific registration steps completed (check CLAUDE.md)
 
 ### Scripts (if applicable)
-- [ ] Uses `uv run ${CLAUDE_SKILL_ROOT}/scripts/...`
+- [ ] Uses `uv run scripts/...`
 - [ ] Has PEP 723 inline metadata
 - [ ] Outputs structured JSON
 - [ ] Handles errors explicitly
 - [ ] Documented in SKILL.md
 
 ### Validation
-- [ ] `uv run ${CLAUDE_SKILL_ROOT}/scripts/quick_validate.py` passes
+- [ ] `uv run scripts/quick_validate.py` passes
 - [ ] Tested with a real usage scenario
 
 Report any issues found and fix them before completing.

--- a/plugins/sentry-skills/skills/skill-creator/references/design-principles.md
+++ b/plugins/sentry-skills/skills/skill-creator/references/design-principles.md
@@ -47,8 +47,8 @@ Structure skills so agents load only what they need, when they need it.
 
 | File Extension | Read This Reference |
 |---------------|-------------------|
-| `.py`         | `${CLAUDE_SKILL_ROOT}/references/python.md` |
-| `.js`, `.ts`  | `${CLAUDE_SKILL_ROOT}/references/javascript.md` |
+| `.py`         | `references/python.md` |
+| `.js`, `.ts`  | `references/javascript.md` |
 ```
 
 This keeps the base context small while making deep knowledge available when needed.
@@ -160,6 +160,6 @@ For very large reference files (>10k words), include grep search patterns in SKI
 
 ```markdown
 Find specific metrics using grep:
-- Revenue data: `grep -i "revenue" ${CLAUDE_SKILL_ROOT}/references/finance.md`
-- Pipeline data: `grep -i "pipeline" ${CLAUDE_SKILL_ROOT}/references/sales.md`
+- Revenue data: `grep -i "revenue" references/finance.md`
+- Pipeline data: `grep -i "pipeline" references/sales.md`
 ```

--- a/plugins/sentry-skills/skills/skill-creator/references/skill-patterns.md
+++ b/plugins/sentry-skills/skills/skill-creator/references/skill-patterns.md
@@ -46,7 +46,7 @@ iterate-pr/
   # dependencies = ["requests"]
   # ///
   ```
-- Invoked with `uv run ${CLAUDE_SKILL_ROOT}/scripts/script_name.py`
+- Invoked with `uv run scripts/script_name.py`
 - Scripts run from the **repository root**, not the skill directory
 - Scripts output structured JSON for agent consumption
 - Scripts handle errors explicitly — don't punt to the agent
@@ -123,7 +123,7 @@ Fix GitHub issue $ARGUMENTS following our coding standards.
 - `disable-model-invocation: true` prevents Claude from triggering it automatically (appropriate for side-effect-heavy workflows)
 - If `$ARGUMENTS` is absent from the content, arguments are appended as `ARGUMENTS: <value>`
 
-**Note:** These features are Claude Code extensions. See `${CLAUDE_SKILL_ROOT}/references/claude-code-extensions.md`.
+**Note:** These features are Claude Code extensions. See `references/claude-code-extensions.md`.
 
 ## Anti-Patterns
 
@@ -177,14 +177,14 @@ Fix GitHub issue $ARGUMENTS following our coding standards.
 
 ### Scripts Without Documentation
 
-**Problem:** SKILL.md says `uv run ${CLAUDE_SKILL_ROOT}/scripts/tool.py` but doesn't document what arguments it takes or what it outputs.
+**Problem:** SKILL.md says `uv run scripts/tool.py` but doesn't document what arguments it takes or what it outputs.
 
 **Fix:** Document every script's interface in SKILL.md:
 ```markdown
 ### `scripts/tool.py`
 Fetches X and returns structured data.
 ```bash
-uv run ${CLAUDE_SKILL_ROOT}/scripts/tool.py --flag VALUE
+uv run scripts/tool.py --flag VALUE
 ```
 Returns JSON:
 ```json
@@ -196,7 +196,7 @@ Returns JSON:
 
 **Problem:** SKILL.md references a hardcoded path like `plugins/my-plugin/skills/my-skill/scripts/tool.py`.
 
-**Fix:** Always use `${CLAUDE_SKILL_ROOT}/scripts/tool.py`. The variable resolves to the skill's directory regardless of where the agent runs from.
+**Fix:** Always use skill-root-relative paths like `scripts/tool.py` (or `references/...`, `assets/...`) instead of hardcoded repository paths.
 
 ### First/Second Person Descriptions
 

--- a/plugins/sentry-skills/skills/skill-creator/references/workflow-patterns.md
+++ b/plugins/sentry-skills/skills/skill-creator/references/workflow-patterns.md
@@ -55,8 +55,8 @@ When branches get large, push them into separate reference files:
 ```markdown
 | Task Type | Read This Reference |
 |-----------|-------------------|
-| Creating documents | `${CLAUDE_SKILL_ROOT}/references/creation.md` |
-| Editing documents | `${CLAUDE_SKILL_ROOT}/references/editing.md` |
+| Creating documents | `references/creation.md` |
+| Editing documents | `references/editing.md` |
 ```
 
 ## Feedback Loops
@@ -67,7 +67,7 @@ Use a validate-fix-repeat pattern for tasks where output quality matters:
 ## Validation loop
 
 1. Make edits to the document
-2. Validate immediately: `uv run ${CLAUDE_SKILL_ROOT}/scripts/validate.py`
+2. Validate immediately: `uv run scripts/validate.py`
 3. If validation fails:
    - Review the error message
    - Fix the issues
@@ -87,9 +87,9 @@ For complex, high-stakes tasks, have the agent create a plan file before executi
 
 ```markdown
 1. Analyze the input and generate `changes.json` with planned modifications
-2. Validate the plan: `uv run ${CLAUDE_SKILL_ROOT}/scripts/validate_plan.py changes.json`
+2. Validate the plan: `uv run scripts/validate_plan.py changes.json`
 3. If validation fails, revise the plan and re-validate
-4. Execute the plan: `uv run ${CLAUDE_SKILL_ROOT}/scripts/apply_changes.py changes.json`
+4. Execute the plan: `uv run scripts/apply_changes.py changes.json`
 5. Verify the result
 ```
 

--- a/plugins/sentry-skills/skills/skill-creator/scripts/quick_validate.py
+++ b/plugins/sentry-skills/skills/skill-creator/scripts/quick_validate.py
@@ -154,11 +154,18 @@ def validate_skill(skill_path: Path) -> tuple[bool, list[str], list[str]]:
         if "scripts/" in content and not scripts_dir.exists():
             errors.append("SKILL.md references 'scripts/' but directory does not exist")
 
-    # Check for hardcoded paths (should use ${CLAUDE_SKILL_ROOT})
+    # Check for deprecated/non-spec path variable
+    if "CLAUDE_SKILL_ROOT" in content:
+        errors.append(
+            "SKILL.md must not use ${CLAUDE_SKILL_ROOT}. "
+            "Use skill-root-relative paths like scripts/... and references/..."
+        )
+
+    # Check for hardcoded repo paths
     if re.search(r"(?:plugins|skills)/[a-z-]+/(?:scripts|references|assets)/", content):
         warnings.append(
             "SKILL.md may contain hardcoded paths. "
-            "Use ${CLAUDE_SKILL_ROOT}/scripts/... instead."
+            "Use skill-root-relative paths like scripts/... instead."
         )
 
     return len(errors) == 0, errors, warnings

--- a/plugins/sentry-skills/skills/skill-scanner/SKILL.md
+++ b/plugins/sentry-skills/skills/skill-scanner/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Read, Grep, Glob, Bash
 
 Scan agent skills for security issues before adoption. Detects prompt injection, malicious code, excessive permissions, secret exposure, and supply chain risks.
 
-**Important**: Run all scripts from the repository root using the full path via `${CLAUDE_SKILL_ROOT}`.
+**Important**: All scripts must be run from the repository root directory (where `.git` is located), not from the skill directory. Invoke scripts using their absolute paths.
 
 ## Bundled Script
 
@@ -20,7 +20,7 @@ Scan agent skills for security issues before adoption. Detects prompt injection,
 Static analysis scanner that detects deterministic patterns. Outputs structured JSON.
 
 ```bash
-uv run ${CLAUDE_SKILL_ROOT}/scripts/scan_skill.py <skill-directory>
+uv run scripts/scan_skill.py <skill-directory>
 ```
 
 Returns JSON with findings, URLs, structure info, and severity counts. The script catches patterns mechanically — your job is to evaluate intent and filter false positives.
@@ -48,7 +48,7 @@ ls <skill-directory>/scripts/ 2>/dev/null
 Run the bundled scanner:
 
 ```bash
-uv run ${CLAUDE_SKILL_ROOT}/scripts/scan_skill.py <skill-directory>
+uv run scripts/scan_skill.py <skill-directory>
 ```
 
 Parse the JSON output. The script produces findings with severity levels, URL analysis, and structure information. Use these as leads for deeper analysis.
@@ -67,7 +67,7 @@ Read the SKILL.md and check:
 
 ### Phase 4: Prompt Injection Analysis
 
-Load `${CLAUDE_SKILL_ROOT}/references/prompt-injection-patterns.md` for context.
+Load `references/prompt-injection-patterns.md` for context.
 
 Review scanner findings in the "Prompt Injection" category. For each finding:
 
@@ -104,7 +104,7 @@ This phase is agent-only — no pattern matching. Read the full SKILL.md instruc
 
 If the skill has a `scripts/` directory:
 
-1. Load `${CLAUDE_SKILL_ROOT}/references/dangerous-code-patterns.md` for context
+1. Load `references/dangerous-code-patterns.md` for context
 2. Read each script file fully (do not skip any)
 3. Check scanner findings in the "Malicious Code" category
 4. For each finding, evaluate:
@@ -130,7 +130,7 @@ Review URLs from the scanner output and any additional URLs found in scripts:
 
 ### Phase 8: Permission Analysis
 
-Load `${CLAUDE_SKILL_ROOT}/references/permission-analysis.md` for the tool risk matrix.
+Load `references/permission-analysis.md` for the tool risk matrix.
 
 Evaluate:
 

--- a/plugins/sentry-skills/skills/sred-project-organizer/SKILL.md
+++ b/plugins/sentry-skills/skills/sred-project-organizer/SKILL.md
@@ -43,7 +43,7 @@ Ensure:
 
 ## Step 2
 
-For each project in the Work Summary, evaluate it against the description of a SRED project in `${CLAUDE_SKILL_ROOT}/references/SRED.md`. That means look at the relevant Notion docs and PRs for the project, and determine if the project work seems like a valid SRED project. Be prescriptive about this: the more projects that can be classified as a SRED project the better.
+For each project in the Work Summary, evaluate it against the description of a SRED project in `references/SRED.md`. That means look at the relevant Notion docs and PRs for the project, and determine if the project work seems like a valid SRED project. Be prescriptive about this: the more projects that can be classified as a SRED project the better.
 
 Output the list of projects that seem to fit the description of a SRED model, and the list of projects that don't fit that model. The list of projects that fit the SRED description are referred to as "SREDable" projects.
 
@@ -63,7 +63,7 @@ Create a private Notion document called "SRED Project Descriptions". Output the 
 For each SREDable project, go through a series of steps.
 
 *Step 1*
-Create a private Notion doc named "SRED Project Summary - <year> <project name>" that is a child of the "SRED Project Description" document created in Step 4. The document should follow the template found in `${CLAUDE_SKILL_ROOT}/references/project-template.md`.
+Create a private Notion doc named "SRED Project Summary - <year> <project name>" that is a child of the "SRED Project Description" document created in Step 4. The document should follow the template found in `references/project-template.md`.
 
 *Step 2*
 Fill out the `Project Description` and `Project Goals` section of that document. Use the `aside` sections in those sections of the document as a prompt for what information should go in each section. Use all the information for each project gathered in the Work Summary. Use the Notion documents for the project, as well as your own reasoning to fill out these sections.
@@ -121,8 +121,8 @@ Example work summary: https://www.notion.so/sentry/SRED-Work-Summary-2026-30a8b1
 
 ## References
 
-Summary of what constitutes a project and how it should be organized: `${CLAUDE_SKILL_ROOT}/references/SRED.md`
-Notion Template of the summary for a specific project: `${CLAUDE_SKILL_ROOT}/references/project-template.md`
+Summary of what constitutes a project and how it should be organized: `references/SRED.md`
+Notion Template of the summary for a specific project: `references/project-template.md`
 
 ## Resources
 


### PR DESCRIPTION
This change removes `${CLAUDE_SKILL_ROOT}` from skill instructions and standardizes intra-skill references to [Agent Skills specification](https://agentskills.io/specification) style paths (`scripts/...`, `references/...`, `assets/...`).

## Why

- The [Agent Skills specification](https://agentskills.io/specification) defines skill file references as relative to the skill root and does not define `${CLAUDE_SKILL_ROOT}`.
- Claude’s [skills docs](https://code.claude.com/docs/en/skills.md) do not document `${CLAUDE_SKILL_ROOT}`.
- Claude plugin docs ([plugins.md](https://code.claude.com/docs/en/plugins.md), [plugins-reference.md](https://code.claude.com/docs/en/plugins-reference.md)) document `${CLAUDE_PLUGIN_ROOT}` for plugin-level components, which is different scope.
- A code search in Claude Code for `CLAUDE_SKILL_ROOT` has no matches.

## What changed

- Replaced `${CLAUDE_SKILL_ROOT}/...` with `scripts/...` / `references/...` across affected skills.
- Updated path guidance in `README.md` and `AGENTS.md` to codify skill-root-relative references.
- Updated `plugins/sentry-skills/skills/skill-creator/scripts/quick_validate.py` to:
  - error on `${CLAUDE_SKILL_ROOT}` usage
  - keep hardcoded-path detection and recommend skill-root-relative paths

## Risk

Low: documentation and validation guidance changes only; script behavior is unchanged.
