### PR TITLE
fix(iterate-pr): Improve fix thoroughness and replace blocking CI wait

### DIFF
--- a/plugins/sentry-skills/skills/iterate-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/iterate-pr/SKILL.md
@@ -143,7 +143,7 @@ Poll CI status and review feedback in a loop instead of blocking:
 
 ### 8. Repeat
 
-Return to step 2 if CI failed or new feedback appeared in step 7.
+If step 7 required code changes (from new feedback after CI passed), return to step 2 for a fresh cycle. CI failures during monitoring are already handled within step 7's polling loop.
 
 ## Exit Conditions
 


### PR DESCRIPTION
Improve the iterate-pr skill to produce more reliable fixes and use CI wait time productively instead of blocking idle.

**Root-cause analysis over surface fixes:** Steps 3 and 5 now require understanding why something failed, checking for related issues in nearby code, and fixing all instances — not just the one mentioned. Step 5 explicitly prohibits the "quick fix and hope" approach.

**Local verification before push:** New step 6 requires re-running the specific failed test, linter, or type checker locally before committing. No more pushing known-broken code.

**Active CI monitoring:** Replaces the blocking `gh pr checks --watch` (which wasted 5-20+ minutes doing nothing) with a polling loop that addresses incoming review feedback while CI runs. This collapses the old steps 7-9 into steps 7-8.

**Stricter retry limit:** Reduced from 3 to 2 attempts for the same failure, pressuring thorough first-attempt fixes.

No changes to the bundled Python scripts (`fetch_pr_checks.py`, `fetch_pr_feedback.py`).