### PR TITLE
feat(iterate-pr): Add comment replies to processed review feedback

### DIFF
--- a/plugins/sentry-skills/skills/iterate-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/iterate-pr/SKILL.md
@@ -50,6 +50,9 @@ Returns JSON with feedback categorized as:
 
 Review bot feedback (from Sentry, Warden, Cursor, Bugbot, CodeQL, etc.) appears in `high`/`medium`/`low` with `review_bot: true` — it is NOT placed in the `bot` bucket.
 
+Each feedback item may also include:
+- `thread_id` - GraphQL node ID for inline review comments (used for replies)
+
 ## Workflow
 
 ### 1. Identify PR
@@ -95,6 +98,22 @@ Which would you like to address? (e.g., "1,3" or "all" or "none")
 **Skip silently:**
 - `resolved` threads
 - `bot` comments (informational only — Codecov, Dependabot, etc.)
+
+#### Replying to Comments
+
+After processing each inline review comment, reply on the PR thread to acknowledge the action taken. Only reply to items with a `thread_id` (inline review comments).
+
+**When to reply:**
+- `high` and `medium` items — whether fixed or determined to be false positives
+- `low` items — whether fixed or declined by the user
+
+**How to reply:** Use the `addPullRequestReviewThreadReply` GraphQL mutation with `pullRequestReviewThreadId` and `body` inputs.
+
+**Reply format:**
+- 1-2 sentences: what was changed, why it's not an issue, or acknowledgment of declined items
+- End every reply with `\n\n- Claude Code`
+- Before replying, check if the thread already has a reply ending with `- Claude Code` to avoid duplicates on re-loops
+- If the `gh api` call fails, log and continue — do not block the workflow
 
 ### 4. Check CI Status
 

--- a/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_feedback.py
+++ b/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_feedback.py
@@ -276,6 +276,7 @@ def extract_feedback_item(
     is_resolved: bool = False,
     is_outdated: bool = False,
     review_bot: bool = False,
+    thread_id: str | None = None,
 ) -> dict[str, Any]:
     """Create a standardized feedback item."""
     # Truncate long bodies for summary
@@ -300,6 +301,8 @@ def extract_feedback_item(
         item["outdated"] = True
     if review_bot:
         item["review_bot"] = True
+    if thread_id:
+        item["thread_id"] = thread_id
 
     return item
 
@@ -371,6 +374,7 @@ def main():
         is_resolved = thread.get("isResolved", False)
         is_outdated = thread.get("isOutdated", False)
 
+        thread_id = thread.get("id")
         item = extract_feedback_item(
             body=body,
             author=author,
@@ -378,9 +382,9 @@ def main():
             line=thread.get("line"),
             is_resolved=is_resolved,
             is_outdated=is_outdated,
+            thread_id=thread_id,
         )
 
-        thread_id = thread.get("id")
         if thread_id:
             seen_thread_ids.add(thread_id)
 


### PR DESCRIPTION
When the iterate-pr skill processes review comments, reviewers have no way
to know what action was taken without re-checking the code. This adds the
ability for the agent to reply directly on each PR review thread.

**Script change:** The `fetch_pr_feedback.py` script already fetched GraphQL
thread IDs but dropped them from output. Now `thread_id` is threaded through
`extract_feedback_item()` and included in the JSON output for inline review
comments.

**Skill change:** SKILL.md Step 3 now includes a "Replying to Comments"
sub-section that instructs the agent to reply to each processed inline
comment using the `addPullRequestReviewThreadReply` GraphQL mutation.
Replies end with `- Claude Code` to make it clear they came from the AI
(since they post under the user's GitHub account). Includes duplicate
protection for workflow re-loops and graceful failure handling.

Ref: https://github.com/getsentry/sentry/pull/109161#discussion_r2843795106