### PR TITLE
fix(iterate-pr): Parse tab-separated output in fetch_pr_checks

### DIFF
--- a/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_checks.py
+++ b/plugins/sentry-skills/skills/iterate-pr/scripts/fetch_pr_checks.py
@@ -57,8 +57,9 @@ def get_checks(pr_number: int | None = None) -> list[dict[str, Any]]:
             args,
             capture_output=True,
             text=True,
-            check=True,
         )
+        if not result.stdout.strip():
+            return []
         checks = []
         for line in result.stdout.strip().split("\n"):
             if not line.strip():
@@ -72,7 +73,7 @@ def get_checks(pr_number: int | None = None) -> list[dict[str, Any]]:
                     "workflow": "",
                 })
         return checks
-    except (subprocess.CalledProcessError, Exception):
+    except Exception:
         return []
 
 


### PR DESCRIPTION
The `get_checks()` function in `fetch_pr_checks.py` was using `--json name,state,bucket,link,workflow` with `gh pr checks`, but this flag is not supported by the GitHub CLI for the `pr checks` subcommand.

This replaces the broken JSON parsing with direct `subprocess.run` that parses the tab-separated text output format that `gh pr checks` actually produces (columns: name, status, duration, URL).

This is the script-side companion to commit 86a548a which previously fixed the same issue in the SKILL.md documentation but left the Python script unchanged.