### PR TITLE
ref(iterate-pr): Update reply attribution to italic signature format

### DIFF
--- a/plugins/sentry-skills/skills/iterate-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/iterate-pr/SKILL.md
@@ -111,8 +111,8 @@ After processing each inline review comment, reply on the PR thread to acknowled
 
 **Reply format:**
 - 1-2 sentences: what was changed, why it's not an issue, or acknowledgment of declined items
-- End every reply with `\n\n- Claude Code`
-- Before replying, check if the thread already has a reply ending with `- Claude Code` to avoid duplicates on re-loops
+- End every reply with `\n\n*— Claude Code*`
+- Before replying, check if the thread already has a reply ending with `*- Claude Code*` or `*— Claude Code*` to avoid duplicates on re-loops
 - If the `gh api` call fails, log and continue — do not block the workflow
 
 ### 4. Check CI Status


### PR DESCRIPTION
Change the PR review reply signature from bullet point format (`- Claude Code`)
to an italic signature line (`*— Claude Code*`). This provides better visual
separation from the reply content and avoids GitHub's list/block rendering quirks.

Also improves the duplicate detection logic to check for both the regular hyphen
(`- Claude Code`) and em-dash (`— Claude Code`) variants, ensuring attributions
aren't duplicated when the skill re-loops through feedback.