### PR TITLE
docs(readme): Add note pointing to sentry-for-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sentry Skills
 
-> **Note:** For skills to help set up Sentry in your project or debug production issues, see https://github.com/getsentry/sentry-for-ai
+> [!NOTE]
+> For skills to help set up Sentry in your project or debug production issues, see https://github.com/getsentry/sentry-for-ai
 
 Agent skills for Sentry employees, following the [Agent Skills](https://agentskills.io) open format.
 


### PR DESCRIPTION
Adds a note at the top of the README pointing users to https://github.com/getsentry/sentry-for-ai for skills related to setting up Sentry in their project or debugging production issues.