### PR TITLE
ref(agents-md): Improve skill with research-backed best practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,59 +1,34 @@
-# Sentry Agent Skills
+# Agent Instructions
 
-A collection of agent skills for use by Sentry employees, primarily designed for [Claude Code](https://claude.ai/claude-code).
-
-This repository is structured as a Claude Code plugin (see `plugins/sentry-skills/`), but the skills themselves follow the open [Agent Skills specification](https://agentskills.io) format to maintain compatibility with other tools that adopt the standard.
-
-## Structure
-
+## Skill Structure
 ```
 plugins/sentry-skills/skills/<skill-name>/SKILL.md
 ```
 
-Each skill is a directory containing a `SKILL.md` file with YAML frontmatter (`name`, `description`) and markdown instructions.
+## Creating/Updating Skills
+ALWAYS use `/skill-creator` — it handles requirements, writing, registration, and validation.
 
-## Creating a Skill
-
+### Registration Checklist
 1. Create `plugins/sentry-skills/skills/<skill-name>/SKILL.md`
-2. Add YAML frontmatter (see below)
-3. Write clear instructions in markdown
-4. Update `README.md` to include the new skill in the Available Skills table
-5. Update the skills allowlist in `plugins/sentry-skills/skills/claude-settings-audit/SKILL.md`
-6. Add the skill to `.claude/settings.json` in the `permissions.allow` array as `Skill(sentry-skills:<skill-name>)`
+2. Add to `README.md` Available Skills table
+3. Add to `.claude/settings.json`: `Skill(sentry-skills:<skill-name>)`
+4. Add to allowlist in `plugins/sentry-skills/skills/claude-settings-audit/SKILL.md`
 
-### Frontmatter
+## Key Conventions
+- Frontmatter `---` must be the **first line** of SKILL.md — no comments before it
+- `name` field must match the directory name exactly
+- `description` includes trigger keywords — this is how agents discover the skill
+- Attribution comments go **after** the closing `---`
+- Python scripts: always use `uv run <script>`, never `python` or `python3`
+- Keep SKILL.md under 500 lines; move reference material to `references/`
 
-**Important:** The YAML frontmatter must be at the very beginning of the file. Do not place comments or any other content before it—parsers expect `---` as the first line.
-
-**Required:**
-- `name` - kebab-case, 1-64 chars
-- `description` - up to 1024 chars, include trigger keywords
-
-**Optional:**
-- `allowed-tools` - comma-separated list of permitted tools
-- `license` - license name or path (for attribution, place a LICENSE file in the skill directory)
-- `compatibility` - environment requirements (max 500 chars)
-
-```yaml
----
-name: example-skill
-description: What this skill does and when to use it. Include trigger keywords.
-allowed-tools: Read, Grep, Glob, Bash
-license: LICENSE
----
-
-<!-- Attribution comments go AFTER the frontmatter -->
-
-# Example Skill
-
-Instructions for the agent.
+## Commit Attribution
+AI commits MUST include:
+```
+Co-Authored-By: (the agent model's name and attribution byline)
 ```
 
-## Skill Design Guidelines
-
-When writing skills that include Python scripts, always instruct the agent to use `uv run <script>` instead of `python <script>` or `python3 <script>`.
-
 ## References
-
+- Skill template and optional fields: `README.md`
+- Testing and PR workflow: `CONTRIBUTING.md`
 - [Agent Skills Spec](https://agentskills.io/specification)
-- [Sentry Engineering Practices](https://develop.sentry.dev/engineering-practices/)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Works with Claude Code, Cursor, Cline, GitHub Copilot, and other compatible agen
 | [find-bugs](plugins/sentry-skills/skills/find-bugs/SKILL.md) | Find bugs and security vulnerabilities in branch changes |
 | [iterate-pr](plugins/sentry-skills/skills/iterate-pr/SKILL.md) | Iterate on a PR until CI passes and feedback is addressed |
 | [claude-settings-audit](plugins/sentry-skills/skills/claude-settings-audit/SKILL.md) | Analyze repo and generate recommended Claude Code settings.json permissions |
-| [agents-md](plugins/sentry-skills/skills/agents-md/SKILL.md) | Maintain AGENTS.md with concise agent instructions |
+| [agents-md](plugins/sentry-skills/skills/agents-md/SKILL.md) | Maintain AGENTS.md with research-backed best practices for minimal agent docs |
 | [brand-guidelines](plugins/sentry-skills/skills/brand-guidelines/SKILL.md) | Write copy following Sentry brand guidelines |
 | [doc-coauthoring](plugins/sentry-skills/skills/doc-coauthoring/SKILL.md) | Structured workflow for co-authoring documentation, proposals, and specs |
 | [security-review](plugins/sentry-skills/skills/security-review/SKILL.md) | Systematic security code review following OWASP guidelines |

--- a/plugins/sentry-skills/skills/agents-md/SKILL.md
+++ b/plugins/sentry-skills/skills/agents-md/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: agents-md
-description: This skill should be used when the user asks to "create AGENTS.md", "update AGENTS.md", "maintain agent docs", "set up CLAUDE.md", or needs to keep agent instructions concise. Guides discovery of local skills and enforces minimal documentation style.
+description: This skill should be used when the user asks to "create AGENTS.md", "update AGENTS.md", "maintain agent docs", "set up CLAUDE.md", or needs to keep agent instructions concise. Enforces research-backed best practices for minimal, high-signal agent documentation.
 ---
 
 # Maintaining AGENTS.md
 
-AGENTS.md is the canonical agent-facing documentation. Keep it minimal—agents are capable and don't need hand-holding.
+AGENTS.md is the canonical agent-facing documentation. Keep it minimal—agents are capable and don't need hand-holding. Target under 60 lines; never exceed 100. Instruction-following quality degrades as document length increases.
 
 ## File Setup
 
@@ -14,23 +14,23 @@ AGENTS.md is the canonical agent-facing documentation. Keep it minimal—agents 
 
 ## Before Writing
 
-Discover local skills to reference:
+Analyze the project to understand what belongs in the file:
 
-```bash
-find .claude/skills -name "SKILL.md" 2>/dev/null
-ls plugins/*/skills/*/SKILL.md 2>/dev/null
-```
-
-Read each skill's frontmatter to understand when to reference it.
+1. **Package manager** — Check for lock files (`pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `uv.lock`, `poetry.lock`)
+2. **Linter/formatter configs** — Look for `.eslintrc`, `biome.json`, `ruff.toml`, `.prettierrc`, etc. (don't duplicate these in AGENTS.md)
+3. **CI/build commands** — Check `Makefile`, `package.json` scripts, CI configs for canonical commands
+4. **Monorepo indicators** — Check for `pnpm-workspace.yaml`, `nx.json`, Cargo workspace, or subdirectory `package.json` files
+5. **Existing conventions** — Check for existing CONTRIBUTING.md, docs/, or README patterns
 
 ## Writing Rules
 
-- **Headers + bullets** - No paragraphs
-- **Code blocks** - For commands and templates
-- **Reference, don't duplicate** - Point to skills: "Use `db-migrate` skill. See `.claude/skills/db-migrate/SKILL.md`"
-- **No filler** - No intros, conclusions, or pleasantries
-- **Trust capabilities** - Omit obvious context
-- **Skill updates** - ALWAYS use `/skill-creator` when creating or updating skills
+- **Headers + bullets** — No paragraphs
+- **Code blocks** — For commands and templates
+- **Reference, don't embed** — Point to existing docs: "See `CONTRIBUTING.md` for setup" or "Follow patterns in `src/api/routes/`"
+- **No filler** — No intros, conclusions, or pleasantries
+- **Trust capabilities** — Omit obvious context
+- **Prefer file-scoped commands** — Per-file test/lint/typecheck commands over project-wide builds
+- **Don't duplicate linters** — Code style lives in linter configs, not AGENTS.md
 
 ## Required Sections
 
@@ -39,6 +39,17 @@ Which tool and key commands only:
 ```markdown
 ## Package Manager
 Use **pnpm**: `pnpm install`, `pnpm dev`, `pnpm test`
+```
+
+### File-Scoped Commands
+Per-file commands are faster and cheaper than full project builds. Always include when available:
+```markdown
+## File-Scoped Commands
+| Task | Command |
+|------|---------|
+| Typecheck | `pnpm tsc --noEmit path/to/file.ts` |
+| Lint | `pnpm eslint path/to/file.ts` |
+| Test | `pnpm jest path/to/file.test.ts` |
 ```
 
 ### Commit Attribution
@@ -55,29 +66,23 @@ Example: `Co-Authored-By: Claude Sonnet 4 <noreply@example.com>`
 ### Key Conventions
 Project-specific patterns agents must follow. Keep brief.
 
-### Local Skills
-Reference each discovered skill:
-```markdown
-## Database
-Use `db-migrate` skill for schema changes. See `.claude/skills/db-migrate/SKILL.md`
-
-## Testing
-Use `write-tests` skill. See `.claude/skills/write-tests/SKILL.md`
-```
-
 ## Optional Sections
 
 Add only if truly needed:
 - API route patterns (show template, not explanation)
 - CLI commands (table format)
 - File naming conventions
+- Project structure hints (point to critical files, flag legacy code to avoid)
+- Monorepo overrides (subdirectory `AGENTS.md` files override root)
 
 ## Anti-Patterns
 
 Omit these:
 - "Welcome to..." or "This document explains..."
 - "You should..." or "Remember to..."
-- Content duplicated from skills (reference instead)
+- Linter/formatter rules already in config files (`.eslintrc`, `biome.json`, `ruff.toml`)
+- Listing installed skills or plugins (agents discover these automatically)
+- Full project-wide build commands when file-scoped alternatives exist
 - Obvious instructions ("run tests", "write clean code")
 - Explanations of why (just say what)
 - Long prose paragraphs
@@ -96,14 +101,15 @@ AI commits MUST include:
 Co-Authored-By: (the agent model's name and attribution byline)
 ```
 
+## File-Scoped Commands
+| Task | Command |
+|------|---------|
+| Typecheck | `pnpm tsc --noEmit path/to/file.ts` |
+| Lint | `pnpm eslint path/to/file.ts` |
+| Test | `pnpm jest path/to/file.test.ts` |
+
 ## API Routes
 [Template code block]
-
-## Database
-Use `db-migrate` skill. See `.claude/skills/db-migrate/SKILL.md`
-
-## Testing
-Use `write-tests` skill. See `.claude/skills/write-tests/SKILL.md`
 
 ## CLI
 | Command | Description |


### PR DESCRIPTION
Replace the agents-md skill's skill-discovery focus with a project-analysis
approach based on research from the AGENTS.md spec, OpenAI Codex guidance,
and other sources on effective agent documentation.

Key changes to the skill:
- Add line budget guidance (target 60 lines, never exceed 100) since instruction-following degrades with document length
- Replace "discover local skills" pre-writing step with project analysis (package manager, linter configs, CI commands, monorepo indicators)
- Add "File-Scoped Commands" required section — per-file test/lint/typecheck is faster and cheaper than full builds
- Remove "Local Skills" required section — agents discover skills automatically through plugin registration
- Add anti-patterns for linter duplication, listing installed skills, and project-wide builds
- Generalize "Reference, don't duplicate" to "Reference, don't embed" (not skill-specific)

Also rewrites this repo's own AGENTS.md to follow the updated guidance (60→34 lines),
referencing README.md and CONTRIBUTING.md instead of duplicating their content.