### PR TITLE
fix(create-branch): Use GitHub username instead of git user.name

### DIFF
--- a/plugins/sentry-skills/skills/create-branch/SKILL.md
+++ b/plugins/sentry-skills/skills/create-branch/SKILL.md
@@ -10,11 +10,9 @@ Create a git branch with the correct type prefix and a descriptive name followin
 
 ## Step 1: Get the Username Prefix
 
-Run `git config user.name`, take the first word, lowercase it, transliterate accented characters to their ASCII equivalents (e.g. é→e, í→i, ñ→n), then remove any remaining characters that are not ASCII letters or digits.
+Run `gh api user --jq .login` to get the GitHub username.
 
-Example: "Priscila Oliveira" → `priscila`, "José García" → `jose`.
-
-If the result is empty, ask the user for their preferred prefix.
+If the command fails (e.g. not authenticated), ask the user for their preferred prefix.
 
 ## Step 2: Determine the Branch Description
 


### PR DESCRIPTION
Use `gh api user --jq .login` to get the branch prefix instead of deriving it from `git config user.name`.

The previous approach required string manipulation (lowercasing, transliteration, stripping special characters) and could produce a prefix that doesn't match the user's actual GitHub handle. Using the GitHub API directly gives the exact username that will appear in the PR URL and branch list.