### PR TITLE
docs: clarify local plugin install target and clone options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Before merging, test your changes locally:
 
    ```bash
    claude plugin marketplace add ~/path/to/sentry-skills
-   claude plugin install sentry-skills
+   claude plugin install sentry-skills@sentry-skills
    ```
 
 2. **Restart Claude Code** to pick up changes

--- a/README.md
+++ b/README.md
@@ -73,9 +73,13 @@ Works with Claude Code, Cursor, Cline, GitHub Copilot, and other compatible agen
 ### Local Development
 
 ```bash
+# SSH
 git clone git@github.com:getsentry/skills.git ~/sentry-skills
+# or HTTPS
+git clone https://github.com/getsentry/skills.git ~/sentry-skills
+
 claude plugin marketplace add ~/sentry-skills
-claude plugin install sentry-skills
+claude plugin install sentry-skills@sentry-skills
 ```
 
 ### Repository Structure


### PR DESCRIPTION
## What changed
- Updated local testing instructions in `CONTRIBUTING.md` to use the explicit install target:
  - `claude plugin install sentry-skills@sentry-skills`
- Updated `README.md` local development commands to:
  - include both SSH and HTTPS clone options
  - use the same explicit install target (`sentry-skills@sentry-skills`) for consistency

## Why
- The repo had mixed install command variants (`sentry-skills` vs `sentry-skills@sentry-skills`).
- Using one explicit command in both contributor docs reduces ambiguity and makes setup steps more copy/paste-friendly.
- Adding an HTTPS clone option helps contributors who do not have GitHub SSH configured.

## Testing
- `scripts/clone_and_test.sh getsentry/skills`
- Tests: not run (no tests found)
