### PR TITLE
fix: prevent credential leakage in security-review evidence snippets

### DIFF
--- a/plugins/sentry-skills/skills/security-review/SKILL.md
+++ b/plugins/sentry-skills/skills/security-review/SKILL.md
@@ -242,6 +242,8 @@ random.random() for token            # FLAG: Security tokens need secrets module
 
 ## Output Format
 
+**Evidence and secrets:** When including code snippets as evidence, **never reproduce actual secret values** (passwords, API keys, tokens, private keys). Redact them with placeholders (e.g. `api_key = "sk-***REDACTED***"`, `password = "[REDACTED]"`) so the report does not leak credentials.
+
 ```markdown
 ## Security Review: [File/Component Name]
 
@@ -259,7 +261,7 @@ random.random() for token            # FLAG: Security tokens need secrets module
 - **Impact**: [What an attacker could do]
 - **Evidence**:
   ```python
-  [Vulnerable code snippet]
+  [Vulnerable code snippet — redact any secret values; use placeholders]
   ```
 - **Fix**: [How to remediate]
 


### PR DESCRIPTION
## Summary

Fixes a credential-handling issue in the `security-review` skill where evidence snippets could inadvertently reproduce sensitive values from analyzed code.

The previous instructions allowed the agent to include raw code snippets as "evidence", which could cause secrets (e.g. API keys, passwords, tokens) to be echoed verbatim in generated reports.

This PR introduces explicit guidance to **never reproduce actual secret values** and to **always redact credentials using placeholders**.

**Example:**

```python
api_key = "sk-***REDACTED***"
password = "[REDACTED]"
```

This ensures the skill can still provide useful evidence while preventing accidental secret disclosure.

## Motivation

During automated security reviews, the agent may analyze repositories that contain hardcoded credentials or sensitive configuration values. Without explicit instructions to redact them, these secrets may appear in generated reports.

Security tools such as [Snyk](https://skills.sh/getsentry/skills/security-review/security/snyk) flagged this behavior as **insecure credential handling (W007)** — the skill required including "evidence" code snippets and explicitly flagged hardcoded secrets, so if the reviewed code contained secret literals the agent could reproduce them verbatim in its report. By enforcing redaction in the output format, the skill avoids propagating sensitive data while preserving the usefulness of vulnerability evidence.

## Changes

- Added explicit instruction to never reproduce real secret values in evidence snippets.
- Added guidance to redact credentials using placeholders.
- Updated the vulnerable code snippet placeholder to reflect redaction requirements.

## Security Impact

Improves the safety of automated security reviews by ensuring:

- Secrets are not echoed in reports.
- Sensitive credentials are always redacted.
- The skill follows secure reporting practices.

This aligns the skill with standard secure disclosure practices used in security tooling.

## References

- **Snyk security audit (W007):** [security-review — snyk](https://skills.sh/getsentry/skills/security-review/security/snyk) — HIGH risk, insecure credential handling in skill instructions (audited Feb 15, 2026).

## Result

Security analysis tools (e.g. Snyk audit) no longer flag insecure credential handling in the skill instructions.
