### PR TITLE
feat(iterate-pr): Auto-trigger review bots on draft PRs

### DIFF
--- a/plugins/sentry-skills/skills/iterate-pr/SKILL.md
+++ b/plugins/sentry-skills/skills/iterate-pr/SKILL.md
@@ -53,6 +53,14 @@ Review bot feedback (from Sentry, Warden, Cursor, Bugbot, CodeQL, etc.) appears 
 Each feedback item may also include:
 - `thread_id` - GraphQL node ID for inline review comments (used for replies)
 
+### `scripts/trigger_review_bots.py`
+
+Detects active review bots on the repo and triggers them on draft PRs. Scans review/comment authors from the last 10 merged PRs via a single GraphQL query to discover which bots are present, then posts trigger comments for each one. Minimizes (hides) previous trigger comments before posting new ones. Exits early on non-draft PRs.
+
+```bash
+uv run ${CLAUDE_SKILL_ROOT}/scripts/trigger_review_bots.py [--pr NUMBER]
+```
+
 ## Workflow
 
 ### 1. Identify PR
@@ -63,11 +71,19 @@ gh pr view --json number,url,headRefName
 
 Stop if no PR exists for the current branch.
 
-### 2. Gather Review Feedback
+### 2. Trigger Review Bots
+
+**Always run this step** — the script exits early on non-draft PRs:
+
+```bash
+uv run ${CLAUDE_SKILL_ROOT}/scripts/trigger_review_bots.py
+```
+
+### 3. Gather Review Feedback
 
 Run `${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py` to get categorized feedback already posted on the PR.
 
-### 3. Handle Feedback by LOGAF Priority
+### 4. Handle Feedback by LOGAF Priority
 
 **Auto-fix (no prompt):**
 - `high` - must address (blockers, security, changes requested)
@@ -115,13 +131,13 @@ After processing each inline review comment, reply on the PR thread to acknowled
 - Before replying, check if the thread already has a reply ending with `*- Claude Code*` or `*— Claude Code*` to avoid duplicates on re-loops
 - If the `gh api` call fails, log and continue — do not block the workflow
 
-### 4. Check CI Status
+### 5. Check CI Status
 
 Run `${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py` to get structured failure data.
 
 **Wait if pending:** If review bot checks (sentry, warden, cursor, bugbot, seer, codeql) are still running, wait before proceeding—they post actionable feedback that must be evaluated. Informational bots (codecov) are not worth waiting for.
 
-### 5. Fix CI Failures
+### 6. Fix CI Failures
 
 For each failure in the script output:
 1. Read the `log_snippet` and trace backwards from the error to understand WHY it failed — not just what failed
@@ -131,7 +147,7 @@ For each failure in the script output:
 
 Do NOT assume what failed based on check name alone—always read the logs. Do NOT "quick fix and hope" — understand the failure thoroughly before changing code.
 
-### 6. Verify Locally, Then Commit and Push
+### 7. Verify Locally, Then Commit and Push
 
 Before committing, verify your fixes locally:
 - If you fixed a test failure: re-run that specific test locally
@@ -146,23 +162,29 @@ git commit -m "fix: <descriptive message>"
 git push
 ```
 
-### 7. Monitor CI and Address Feedback
+After pushing, trigger review bots so they re-review the latest changes:
+
+```bash
+uv run ${CLAUDE_SKILL_ROOT}/scripts/trigger_review_bots.py
+```
+
+### 8. Monitor CI and Address Feedback
 
 Poll CI status and review feedback in a loop instead of blocking:
 
 1. Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py` to get current CI status
 2. If all checks passed → proceed to exit conditions
-3. If any checks failed (none pending) → return to step 5
+3. If any checks failed (none pending) → return to step 6
 4. If checks are still pending:
    a. Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py` for new review feedback
-   b. Address any new high/medium feedback immediately (same as step 3)
+   b. Address any new high/medium feedback immediately (run without `--summary` to get full details)
    c. If changes were needed, commit and push (this restarts CI), then continue polling
-   d. Sleep 30 seconds, then repeat from sub-step 1
-5. After all checks pass, do a final feedback check: `sleep 10`, then run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py`. Address any new high/medium feedback — if changes are needed, return to step 6.
+   d. Sleep 30 seconds (don't increase on subsequent iterations), then repeat from sub-step 1
+5. After all checks pass, do a final feedback check: `sleep 10`, then run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py`. Address any new high/medium feedback — if changes are needed, return to step 7.
 
-### 8. Repeat
+### 9. Repeat
 
-If step 7 required code changes (from new feedback after CI passed), return to step 2 for a fresh cycle. CI failures during monitoring are already handled within step 7's polling loop.
+If step 8 required code changes (from new feedback after CI passed), return to step 3 for a fresh cycle. CI failures during monitoring are already handled within step 8's polling loop.
 
 ## Exit Conditions
 

--- a/plugins/sentry-skills/skills/iterate-pr/scripts/trigger_review_bots.py
+++ b/plugins/sentry-skills/skills/iterate-pr/scripts/trigger_review_bots.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# ///
+"""
+Detect and trigger review bots on draft PRs.
+
+Usage:
+    python trigger_review_bots.py [--pr PR_NUMBER]
+
+Detects which review bots are active on the repo by scanning review/comment
+authors on the last 10 merged PRs, then posts trigger comments for each
+detected bot. Only triggers on draft PRs — exits early otherwise.
+
+Before posting a new trigger comment, minimizes (hides) any previous trigger
+comments we posted for the same bot to keep the PR conversation clean.
+
+Example:
+    python trigger_review_bots.py
+    python trigger_review_bots.py --pr 123
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+# Maps bot usernames to their trigger commands.
+# Add new bots here as they're discovered.
+TRIGGER_MAP: dict[str, str] = {
+    "cursor": "@cursor review",
+    "sentry": "@sentry review",
+}
+
+# All possible trigger command bodies (lowercased) for matching old comments
+TRIGGER_BODIES: set[str] = {cmd.lower() for cmd in TRIGGER_MAP.values()}
+
+
+def run_gh(args: list[str]) -> dict[str, Any] | list[Any] | None:
+    """Run a gh CLI command and return parsed JSON output."""
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(result.stdout) if result.stdout.strip() else None
+    except subprocess.CalledProcessError as e:
+        print(f"Error running gh {' '.join(args)}: {e.stderr}", file=sys.stderr)
+        return None
+    except json.JSONDecodeError:
+        return None
+
+
+def minimize_comment(node_id: str) -> bool:
+    """Minimize (hide) a comment using the GraphQL API."""
+    query = """
+    mutation($id: ID!) {
+      minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+        clientMutationId
+      }
+    }
+    """
+    try:
+        subprocess.run(
+            [
+                "gh", "api", "graphql",
+                "-f", f"query={query}",
+                "-F", f"id={node_id}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def detect_and_trigger(pr_number: int | None = None) -> dict[str, Any]:
+    """Detect review bots and trigger them on draft PRs.
+
+    Uses a single GraphQL query to fetch:
+    - Current PR's draft status, number, and existing comments
+    - Review/comment authors from the last 10 merged PRs (for bot detection)
+    """
+    # Get repo info
+    repo_info = run_gh(["repo", "view", "--json", "owner,name"])
+    if not repo_info:
+        return {"error": "Could not determine repository"}
+    owner = repo_info.get("owner", {}).get("login", "")
+    repo = repo_info.get("name", "")
+
+    # Get current PR number if not provided
+    if pr_number is None:
+        pr_info = run_gh(["pr", "view", "--json", "number"])
+        if not pr_info:
+            return {"error": "No PR found for current branch"}
+        pr_number = pr_info["number"]
+
+    # Single GraphQL query: current PR info + recent PR review/comment authors
+    query = """
+    query($owner: String!, $repo: String!, $pr: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          isDraft
+          number
+          comments(first: 100) {
+            nodes {
+              id
+              body
+              isMinimized
+            }
+          }
+        }
+        pullRequests(states: MERGED, last: 10) {
+          nodes {
+            reviews(first: 20) {
+              nodes {
+                author { login }
+              }
+            }
+            comments(first: 50) {
+              nodes {
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api", "graphql",
+                "-f", f"query={query}",
+                "-F", f"owner={owner}",
+                "-F", f"repo={repo}",
+                "-F", f"pr={pr_number}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        return {"error": f"GraphQL query failed: {e}"}
+
+    repo_data = data.get("data", {}).get("repository", {})
+    pr_data = repo_data.get("pullRequest", {})
+    is_draft = pr_data.get("isDraft", False)
+
+    if not is_draft:
+        return {"is_draft": False, "triggered": []}
+
+    # Collect unique authors from reviews and comments on recent merged PRs
+    authors: set[str] = set()
+    for pr_node in repo_data.get("pullRequests", {}).get("nodes", []):
+        for review in pr_node.get("reviews", {}).get("nodes", []):
+            login = (review.get("author") or {}).get("login", "")
+            if login:
+                authors.add(login.lower())
+        for comment in pr_node.get("comments", {}).get("nodes", []):
+            login = (comment.get("author") or {}).get("login", "")
+            if login:
+                authors.add(login.lower())
+
+    # Find which bots to trigger
+    bots_to_trigger = {
+        username: cmd
+        for username, cmd in TRIGGER_MAP.items()
+        if username.lower() in authors
+    }
+
+    if not bots_to_trigger:
+        return {"is_draft": True, "triggered": [], "no_bots_found": True}
+
+    # Minimize previous trigger comments (hide as outdated)
+    minimized = 0
+    for comment in pr_data.get("comments", {}).get("nodes", []):
+        body = (comment.get("body") or "").strip().lower()
+        if not comment.get("isMinimized") and body in TRIGGER_BODIES:
+            if minimize_comment(comment["id"]):
+                minimized += 1
+
+    # Post new trigger comments
+    triggered = []
+    for bot_username, trigger_command in bots_to_trigger.items():
+        try:
+            subprocess.run(
+                [
+                    "gh", "api",
+                    f"repos/{owner}/{repo}/issues/{pr_number}/comments",
+                    "-f", f"body={trigger_command}",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            triggered.append(trigger_command)
+        except subprocess.CalledProcessError as e:
+            print(
+                f"Failed to trigger {bot_username}: {e.stderr}",
+                file=sys.stderr,
+            )
+
+    output: dict[str, Any] = {"is_draft": True, "triggered": triggered}
+    if minimized:
+        output["minimized_previous"] = minimized
+    return output
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect and trigger review bots on draft PRs"
+    )
+    parser.add_argument(
+        "--pr", type=int, help="PR number (defaults to current branch PR)"
+    )
+    args = parser.parse_args()
+
+    result = detect_and_trigger(args.pr)
+    print(json.dumps(result, indent=2))
+
+    if "error" in result:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sentry-skills/skills/iterate-pr/scripts/trigger_review_bots.py
+++ b/plugins/sentry-skills/skills/iterate-pr/scripts/trigger_review_bots.py
@@ -64,20 +64,7 @@ def minimize_comment(node_id: str) -> bool:
       }
     }
     """
-    try:
-        subprocess.run(
-            [
-                "gh", "api", "graphql",
-                "-f", f"query={query}",
-                "-F", f"id={node_id}",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return True
-    except subprocess.CalledProcessError:
-        return False
+    return run_gh(["api", "graphql", "-f", f"query={query}", "-F", f"id={node_id}"]) is not None
 
 
 def detect_and_trigger(pr_number: int | None = None) -> dict[str, Any]:
@@ -134,22 +121,15 @@ def detect_and_trigger(pr_number: int | None = None) -> dict[str, Any]:
     }
     """
 
-    try:
-        result = subprocess.run(
-            [
-                "gh", "api", "graphql",
-                "-f", f"query={query}",
-                "-F", f"owner={owner}",
-                "-F", f"repo={repo}",
-                "-F", f"pr={pr_number}",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        data = json.loads(result.stdout)
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-        return {"error": f"GraphQL query failed: {e}"}
+    data = run_gh([
+        "api", "graphql",
+        "-f", f"query={query}",
+        "-F", f"owner={owner}",
+        "-F", f"repo={repo}",
+        "-F", f"pr={pr_number}",
+    ])
+    if not data:
+        return {"error": "GraphQL query failed"}
 
     repo_data = data.get("data", {}).get("repository", {})
     pr_data = repo_data.get("pullRequest", {})
@@ -191,23 +171,13 @@ def detect_and_trigger(pr_number: int | None = None) -> dict[str, Any]:
     # Post new trigger comments
     triggered = []
     for bot_username, trigger_command in bots_to_trigger.items():
-        try:
-            subprocess.run(
-                [
-                    "gh", "api",
-                    f"repos/{owner}/{repo}/issues/{pr_number}/comments",
-                    "-f", f"body={trigger_command}",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
+        result = run_gh([
+            "api",
+            f"repos/{owner}/{repo}/issues/{pr_number}/comments",
+            "-f", f"body={trigger_command}",
+        ])
+        if result is not None:
             triggered.append(trigger_command)
-        except subprocess.CalledProcessError as e:
-            print(
-                f"Failed to trigger {bot_username}: {e.stderr}",
-                file=sys.stderr,
-            )
 
     output: dict[str, Any] = {"is_draft": True, "triggered": triggered}
     if minimized:


### PR DESCRIPTION
## Summary
- Adds `trigger_review_bots.py` script that detects and triggers review bots on draft PRs
- Updates workflow to run the script at startup (step 2) and after each push (step 7)

## Why
Review bots (cursor, sentry) don't auto-run on draft PRs. Users have to manually post `@cursor review` / `@sentry review` after every push. This automates it by:

1. **Detecting** which bots are active — scans review/comment authors from the last 10 merged PRs via a single GraphQL query
2. **Triggering** them — posts the appropriate trigger comment for each detected bot
3. **Cleaning up** — minimizes (hides as outdated) previous trigger comments before posting new ones so the PR conversation stays clean

Uses a hardcoded trigger map (`cursor` → `@cursor review`, `sentry` → `@sentry review`) that's easy to extend.

## Test plan
- [x] Run on a draft PR in a repo with cursor/sentry bots — should detect and trigger both
- [ ] Run on a non-draft PR — should exit early with `is_draft: false`
- [ ] Run twice on same draft PR — previous trigger comments should be minimized before new ones are posted
- [ ] Run on a repo with no known bots — should return `no_bots_found: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)