### PR TITLE
feat(blog-writing-guide): add skimmability and SEO guidance

### DIFF
--- a/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
+++ b/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
@@ -56,6 +56,38 @@ For engineering deep-dives, also address:
 5. **What did we try that didn't work?** (Builds trust)
 6. **What are the known limitations?** (Shows intellectual honesty)
 
+## Formatting for Skimmability
+
+People scroll. Shorter paragraphs are almost always better for keeping people reading.
+
+**Break paragraphs at contrast points.** When a sentence introduces a "but," "however," or shifts perspective, start a new paragraph. Don't bury the turn inside a block of text.
+
+**Bad:**
+> Traditional monitoring tracks requests and latency. That works for stateless HTTP services. AI agents are different. A single run might involve multiple LLM calls, tool executions, and handoffs.
+
+**Good:**
+> Traditional monitoring tracks requests and latency. That works for stateless HTTP services.
+>
+> AI agents are different. A single run might involve multiple LLM calls, tool executions, and handoffs.
+
+The line break before the contrasting point creates visual emphasis. This is standard in online writing even though it breaks traditional paragraph rules.
+
+**One idea per paragraph.** If a paragraph covers two distinct points, split it. Three-sentence paragraphs are fine. One-sentence paragraphs are fine for emphasis.
+
+**No em dashes.** Use commas, periods, or line breaks instead. Em dashes are fine in print but create visual clutter in blog formatting.
+
+## SEO for Developer Content
+
+When targeting a competitive search query:
+
+**Lead generic, close specific.** The first 50-60% of the post should be tool-agnostic educational content (definitions, concepts, metrics, best practices). Introduce your product as an implementation example in the second half. Google ranks guides higher than product pages for informational queries.
+
+**Put keywords in H2s.** Section headings like "Background" and "Architecture" are invisible to search. Use headings that contain the target keywords: "Key metrics for AI agent monitoring" beats "What to measure."
+
+**Include a definitional section.** For any head term ("agent observability", "error monitoring"), top-ranking pages almost always have a "What is X?" section. Include one even if it feels basic.
+
+**Add an FAQ.** 3-4 questions targeting long-tail keywords at the bottom of the post. These can win featured snippets and People Also Ask boxes.
+
 ## Section Headings Must Convey Information
 
 **Weak:** "Background," "Architecture," "Results," "Conclusion"

--- a/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
+++ b/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
@@ -88,6 +88,18 @@ When targeting a competitive search query:
 
 **Add an FAQ.** 3-4 questions targeting long-tail keywords at the bottom of the post. These can win featured snippets and People Also Ask boxes.
 
+## AI Writing Patterns to Avoid
+
+LLM-generated prose has tells. Flag and rewrite these:
+
+- **Staccato dramatic fragments** — "No errors. No timeouts. Every span green." Write normal sentences.
+- **Bumper-sticker aphorisms** — "You can't fix what you can't see." Explain the point instead of coining a phrase.
+- **Three-beat reveals** — "Not X. Not Y. It was Z." Flatten into one sentence.
+- **Smug simplicity** — "That's it." after a code block. Let the code speak.
+- **Parallel structure ad copy** — "X tells you A. Y tells you B." Combine into a natural sentence.
+- **Personality only in the bookends** — AI drafts open personal, go impersonal for 80%, then close with a CTA. Keep the author's voice throughout.
+- **Product-page closers** — "Try X for free. Included on all plans." Connect back to the story instead.
+
 ## Section Headings Must Convey Information
 
 **Weak:** "Background," "Architecture," "Results," "Conclusion"

--- a/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
+++ b/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
@@ -82,7 +82,7 @@ When targeting a competitive search query:
 
 **Lead generic, close specific.** The first 50-60% of the post should be tool-agnostic educational content (definitions, concepts, metrics, best practices). Introduce your product as an implementation example in the second half. Google ranks guides higher than product pages for informational queries.
 
-**Put keywords in H2s.** Section headings like "Background" and "Architecture" are invisible to search. Use headings that contain the target keywords: "Key metrics for AI agent monitoring" beats "What to measure."
+**Put keywords in H2s.** Generic headings are invisible to search. "Key metrics for AI agent monitoring" beats "What to measure." (See **Section Headings** below for good/bad examples.)
 
 **Include a definitional section.** For any head term ("agent observability", "error monitoring"), top-ranking pages almost always have a "What is X?" section. Include one even if it feels basic.
 
@@ -115,10 +115,6 @@ LLM-generated prose has tells. Flag and rewrite these:
 **Personality only in the bookends.** AI drafts open with a personal anecdote, go impersonal for 80% of the post, then close with a CTA. The author's voice should persist throughout.
 - Bad: Personal intro → clinical middle → "Try Sentry for free."
 - Good: First-person asides woven through the post: "this is the part that tripped me up" / "I would have blamed the wrong service."
-
-**Product-page closers.**
-- Bad: "Try Sentry for free. Error monitoring is included on all plans."
-- Good: Link to source code, connect back to the opening story, or give the reader a concrete next step that isn't a signup page.
 
 ## Section Headings Must Convey Information
 
@@ -154,7 +150,7 @@ The title is the highest-leverage sentence in the post. It must stop a developer
 
 ## The Closing
 
-End with something useful — a link to docs, a way to try it, a call to give feedback. Never end with generic hype ("We can't wait to see what you build!") or recaps of what you just said.
+End with something useful: a link to docs, source code, a way to try it, or a call to give feedback. Never end with generic hype ("We can't wait to see what you build!"), recaps of what you just said, or product-page CTAs ("Try Sentry for free. Included on all plans."). Connect back to the story you opened with, or give the reader something concrete to do next.
 
 ## Post Types
 

--- a/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
+++ b/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
@@ -92,13 +92,33 @@ When targeting a competitive search query:
 
 LLM-generated prose has tells. Flag and rewrite these:
 
-- **Staccato dramatic fragments** — "No errors. No timeouts. Every span green." Write normal sentences.
-- **Bumper-sticker aphorisms** — "You can't fix what you can't see." Explain the point instead of coining a phrase.
-- **Three-beat reveals** — "Not X. Not Y. It was Z." Flatten into one sentence.
-- **Smug simplicity** — "That's it." after a code block. Let the code speak.
-- **Parallel structure ad copy** — "X tells you A. Y tells you B." Combine into a natural sentence.
-- **Personality only in the bookends** — AI drafts open personal, go impersonal for 80%, then close with a CTA. Keep the author's voice throughout.
-- **Product-page closers** — "Try X for free. Included on all plans." Connect back to the story instead.
+**Staccato dramatic fragments.**
+- Bad: "No errors. No timeouts. Every span green."
+- Good: "There were no errors, no timeouts, every span was green."
+
+**Bumper-sticker aphorisms.**
+- Bad: "You can't fix what you can't see."
+- Good: "Without traces spanning the full agent graph, you're stuck reading each agent's logs in isolation."
+
+**Three-beat reveals.**
+- Bad: "Not an agent bug. Not a prompt bug. A tool returned weak results."
+- Good: "The root cause wasn't the agent or the prompt — a tool returned weak results that cascaded through the pipeline."
+
+**Smug simplicity.**
+- Bad: [code block] "That's it. That's all you need."
+- Good: [code block] then explain what the code does, or just move on.
+
+**Parallel structure ad copy.**
+- Bad: "Token counts tell you what's expensive. Prompts tell you what's broken."
+- Good: "Token counts show cost, but the prompts and responses are where you'll actually find bugs."
+
+**Personality only in the bookends.** AI drafts open with a personal anecdote, go impersonal for 80% of the post, then close with a CTA. The author's voice should persist throughout.
+- Bad: Personal intro → clinical middle → "Try Sentry for free."
+- Good: "This is the one that got me" / "Based on debugging this system" / "I would have blamed the wrong agent" woven through the post.
+
+**Product-page closers.**
+- Bad: "Try Sentry for free. AI monitoring is included on all plans."
+- Good: Link to the source code, connect back to the opening story, or give the reader a concrete next step that isn't a signup page.
 
 ## Section Headings Must Convey Information
 

--- a/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
+++ b/plugins/sentry-skills/skills/blog-writing-guide/SKILL.md
@@ -93,32 +93,32 @@ When targeting a competitive search query:
 LLM-generated prose has tells. Flag and rewrite these:
 
 **Staccato dramatic fragments.**
-- Bad: "No errors. No timeouts. Every span green."
-- Good: "There were no errors, no timeouts, every span was green."
+- Bad: "No errors. No warnings. Everything green."
+- Good: "There were no errors, no warnings, everything looked fine."
 
 **Bumper-sticker aphorisms.**
 - Bad: "You can't fix what you can't see."
-- Good: "Without traces spanning the full agent graph, you're stuck reading each agent's logs in isolation."
+- Good: "Without visibility into the full request lifecycle, you're guessing."
 
 **Three-beat reveals.**
-- Bad: "Not an agent bug. Not a prompt bug. A tool returned weak results."
-- Good: "The root cause wasn't the agent or the prompt — a tool returned weak results that cascaded through the pipeline."
+- Bad: "Not a config issue. Not a code bug. The deploy was stale."
+- Good: "It wasn't a config issue or a code bug. The deploy was stale."
 
 **Smug simplicity.**
 - Bad: [code block] "That's it. That's all you need."
 - Good: [code block] then explain what the code does, or just move on.
 
 **Parallel structure ad copy.**
-- Bad: "Token counts tell you what's expensive. Prompts tell you what's broken."
-- Good: "Token counts show cost, but the prompts and responses are where you'll actually find bugs."
+- Bad: "Metrics tell you what's broken. Traces tell you why."
+- Good: "Metrics show what's broken, but traces are where you'll actually figure out why."
 
 **Personality only in the bookends.** AI drafts open with a personal anecdote, go impersonal for 80% of the post, then close with a CTA. The author's voice should persist throughout.
 - Bad: Personal intro → clinical middle → "Try Sentry for free."
-- Good: "This is the one that got me" / "Based on debugging this system" / "I would have blamed the wrong agent" woven through the post.
+- Good: First-person asides woven through the post: "this is the part that tripped me up" / "I would have blamed the wrong service."
 
 **Product-page closers.**
-- Bad: "Try Sentry for free. AI monitoring is included on all plans."
-- Good: Link to the source code, connect back to the opening story, or give the reader a concrete next step that isn't a signup page.
+- Bad: "Try Sentry for free. Error monitoring is included on all plans."
+- Good: Link to source code, connect back to the opening story, or give the reader a concrete next step that isn't a signup page.
 
 ## Section Headings Must Convey Information
 


### PR DESCRIPTION
## Summary

Adds two new sections to the blog writing skill based on editorial feedback from Greg Kumparak and SEO learnings from the agent monitoring blog posts.

### Formatting for Skimmability
- Break paragraphs at contrast/pivot points (when sentence shifts to "but"/"however")
- One idea per paragraph, shorter is better for online reading
- No em dashes in blog formatting
- Good/bad example showing the line break pattern

### SEO for Developer Content
- Lead generic (tool-agnostic educational content), close specific (product as example)
- Put target keywords in H2 headings
- Include definitional "What is X?" sections for head terms
- Add FAQ for long-tail keyword targeting

These came from a real editing session where Greg reviewed two Sentry blog drafts and identified consistent patterns around paragraph breaks at contrast points and skimmability. The SEO section came from an Ahrefs content analysis where we found competitors outranking us by leading with tool-agnostic content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)