### PR TITLE
feat(iterate-pr): replace sleep polling with MonitorTool

### DIFF
--- a/skills/iterate-pr/SKILL.md
+++ b/skills/iterate-pr/SKILL.md
@@ -135,17 +135,40 @@ git push
 
 ### 7. Monitor CI and Address Feedback
 
-Poll CI status and review feedback in a loop instead of blocking:
+Use the MonitorTool to poll CI status instead of sleep loops. The MonitorTool runs a script in the background and delivers each stdout line as a notification.
 
 1. Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py` to get current CI status
-2. If all checks passed → proceed to exit conditions
-3. If any checks failed (none pending) → return to step 5
-4. If checks are still pending:
+2. If all checks passed, proceed to exit conditions
+3. If any checks failed (none pending), return to step 5
+4. If checks are still pending, use the MonitorTool to wait until all checks reach a terminal state:
+
+```sh
+while true; do
+  pending=$(gh pr checks --json bucket --jq '[.[] | select(.bucket == "pending")] | length') || { sleep 30; continue; }
+  if [ "$pending" = "0" ]; then
+    failed=$(gh pr checks --json bucket --jq '[.[] | select(.bucket == "fail")] | length') || { sleep 30; continue; }
+    if [ "$failed" != "0" ]; then
+      echo "CHECKS_DONE_WITH_FAILURES"
+    else
+      echo "ALL_CHECKS_PASSED"
+    fi
+    gh pr checks | head -20
+    exit 0
+  fi
+  sleep 30
+done
+```
+
+Set `persistent: false` with `timeout_ms: 900000` (15 min). The `|| { sleep 30; continue; }` retries on transient API errors instead of killing the monitor.
+
+After the monitor fires, re-run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py` and branch: if any checks failed, return to step 5. If all passed, continue to sub-step 5.
+
+While waiting, address any pending feedback:
    a. Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py` for new review feedback
    b. Address any new high/medium feedback immediately (same as step 3)
-   c. If changes were needed, commit and push (this restarts CI), then continue polling
-   d. Sleep 30 seconds (don't increase on subsequent iterations), then repeat from sub-step 1
-5. After all checks pass, do a final feedback check: `sleep 10`, then run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py`. Address any new high/medium feedback — if changes are needed, return to step 6.
+   c. If changes were needed, commit and push (this restarts CI), then start a new monitor
+
+5. After all checks pass, wait 10 seconds for any late-arriving review bot comments, then run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py`. Address any new high/medium feedback. If changes are needed, return to step 6.
 
 ### 8. Repeat
 

--- a/skills/iterate-pr/SKILL.md
+++ b/skills/iterate-pr/SKILL.md
@@ -135,15 +135,28 @@ git push
 
 ### 7. Monitor CI and Address Feedback
 
-Use the MonitorTool to poll CI status instead of sleep loops. The MonitorTool runs a script in the background and delivers each stdout line as a notification.
+Keep monitoring CI status and review feedback in a loop instead of blocking:
 
 1. Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py` to get current CI status
 2. If all checks passed, proceed to exit conditions
 3. If any checks failed (none pending), return to step 5
-4. If checks are still pending, use the MonitorTool to wait until all checks reach a terminal state:
+4. If checks are still pending:
+   a. Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py` for new review feedback
+   b. Address any new high/medium feedback immediately (same as step 3)
+   c. If changes were needed, commit and push (this restarts CI), then continue monitoring from the refreshed branch state
+   d. Sleep 30 seconds (don't increase on subsequent iterations), then repeat from sub-step 1
+5. After all checks pass, wait 10 seconds for late-arriving review bot comments, then run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py`. Address any new high/medium feedback — if changes are needed, return to step 6.
+
+If you're in Claude Code, you can replace the sleep-based wait above with `MonitorTool` so the polling happens in the background instead of consuming context. This is a Claude-only optimization, not the default workflow for other agents.
 
 ```sh
 while true; do
+  total=$(gh pr checks --json bucket --jq 'length') || { sleep 30; continue; }
+  if [ "$total" = "0" ]; then
+    sleep 15
+    continue
+  fi
+
   pending=$(gh pr checks --json bucket --jq '[.[] | select(.bucket == "pending")] | length') || { sleep 30; continue; }
   if [ "$pending" = "0" ]; then
     failed=$(gh pr checks --json bucket --jq '[.[] | select(.bucket == "fail")] | length') || { sleep 30; continue; }
@@ -159,16 +172,13 @@ while true; do
 done
 ```
 
-Set `persistent: false` with `timeout_ms: 900000` (15 min). The `|| { sleep 30; continue; }` retries on transient API errors instead of killing the monitor.
+Run that shell loop through `MonitorTool` with `persistent: false`. Set `timeout_ms` to match the repository's normal CI duration instead of hardcoding a 15-minute timeout.
 
-After the monitor fires, re-run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py` and branch: if any checks failed, return to step 5. If all passed, continue to sub-step 5.
+After `MonitorTool` reports completion, re-run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py`:
+- If any checks failed, return to step 5.
+- If all checks passed, continue to sub-step 5 above.
 
-While waiting, address any pending feedback:
-   a. Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py` for new review feedback
-   b. Address any new high/medium feedback immediately (same as step 3)
-   c. If changes were needed, commit and push (this restarts CI), then start a new monitor
-
-5. After all checks pass, wait 10 seconds for any late-arriving review bot comments, then run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_feedback.py`. Address any new high/medium feedback. If changes are needed, return to step 6.
+If you pushed new changes while monitoring, start a fresh monitor so it watches the new set of CI runs.
 
 ### 8. Repeat
 


### PR DESCRIPTION
hello! full transparency: this is a claude-authored pr. i'm hopping in on the description just to say hi.

i have my own personal skill, very similar to this one, for monitoring PRs. i just updated mine to use the new Monitor tool in claude code, and thought i'd propose such a change here 

my impression was this skill is claude specific, so it's fine to call out a specific claude code tool like `MonitorTool` in the skill itself ([docs](https://code.claude.com/docs/en/tools-reference#monitor-tool))

without ado, the pr description from claude:

***

Replace the `sleep 30` polling loop in step 7 with MonitorTool guidance. The MonitorTool runs a background script that streams stdout lines as notifications, avoiding burning context on repeated sleep/poll cycles.

- Add concrete polling script with transient error handling
- References 'MonitorTool' for explicit tool discovery
- Link to docs: https://code.claude.com/docs/en/tools-reference#monitor-tool
- Link to CC pm's announce-tweet: https://x.com/noahzweben/status/2042332268450963774?s=20 