### PR TITLE
fix(iterate-pr): extract monitor script

### DIFF
--- a/skills/iterate-pr/SKILL.md
+++ b/skills/iterate-pr/SKILL.md
@@ -52,6 +52,18 @@ Returns JSON with feedback categorized as:
 
 Review bot feedback (from Sentry, Warden, Cursor, Bugbot, CodeQL, etc.) appears in `high`/`medium`/`low` with `review_bot: true` — it is NOT placed in the `bot` bucket.
 
+### `scripts/monitor_pr_checks.py`
+
+Monitors PR checks until they all reach a terminal state. Retries transient `gh` failures, treats `skipping` and `cancel` as terminal states, and waits for checks to register after a fresh push instead of exiting early.
+
+```bash
+uv run ${CLAUDE_SKILL_ROOT}/scripts/monitor_pr_checks.py [--pr NUMBER]
+```
+
+Prints one terminal marker followed by a tab-separated check summary:
+- `ALL_CHECKS_PASSED`
+- `CHECKS_DONE_WITH_FAILURES`
+
 ## Workflow
 
 ### 1. Identify PR
@@ -149,30 +161,13 @@ Keep monitoring CI status and review feedback in a loop instead of blocking:
 
 If you're in Claude Code, you can replace the sleep-based wait above with `MonitorTool` so the polling happens in the background instead of consuming context. This is a Claude-only optimization, not the default workflow for other agents.
 
-```sh
-while true; do
-  total=$(gh pr checks --json bucket --jq 'length') || { sleep 30; continue; }
-  if [ "$total" = "0" ]; then
-    sleep 15
-    continue
-  fi
+Run the bundled monitor script through `MonitorTool` with `persistent: false`:
 
-  pending=$(gh pr checks --json bucket --jq '[.[] | select(.bucket == "pending")] | length') || { sleep 30; continue; }
-  if [ "$pending" = "0" ]; then
-    failed=$(gh pr checks --json bucket --jq '[.[] | select(.bucket == "fail")] | length') || { sleep 30; continue; }
-    if [ "$failed" != "0" ]; then
-      echo "CHECKS_DONE_WITH_FAILURES"
-    else
-      echo "ALL_CHECKS_PASSED"
-    fi
-    gh pr checks | head -20
-    exit 0
-  fi
-  sleep 30
-done
+```bash
+uv run ${CLAUDE_SKILL_ROOT}/scripts/monitor_pr_checks.py
 ```
 
-Run that shell loop through `MonitorTool` with `persistent: false`. Set `timeout_ms` to match the repository's normal CI duration instead of hardcoding a 15-minute timeout.
+Set `timeout_ms` to match the repository's normal CI duration instead of hardcoding a 15-minute timeout.
 
 After `MonitorTool` reports completion, re-run `uv run ${CLAUDE_SKILL_ROOT}/scripts/fetch_pr_checks.py`:
 - If any checks failed, return to step 5.

--- a/skills/iterate-pr/scripts/monitor_pr_checks.py
+++ b/skills/iterate-pr/scripts/monitor_pr_checks.py
@@ -30,16 +30,18 @@ import time
 from typing import Any
 
 
-def run_gh_json(args: list[str]) -> list[dict[str, Any]] | dict[str, Any] | None:
+def run_gh_json(
+    args: list[str],
+    allowed_returncodes: tuple[int, ...] = (0,),
+) -> list[dict[str, Any]] | dict[str, Any] | None:
     """Run a gh command that returns JSON."""
-    try:
-        result = subprocess.run(
-            ["gh"] + args,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
+    result = subprocess.run(
+        ["gh"] + args,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode not in allowed_returncodes:
         return None
 
     if not result.stdout.strip():
@@ -72,7 +74,7 @@ def get_checks(pr_number: int) -> list[dict[str, Any]] | None:
         str(pr_number),
         "--json",
         "name,bucket,link",
-    ])
+    ], allowed_returncodes=(0, 1, 8))
     return checks if isinstance(checks, list) else None
 
 
@@ -122,11 +124,14 @@ def main() -> int:
             time.sleep(args.poll_seconds)
             continue
 
+        passed = sum(1 for check in checks if check.get("bucket") == "pass")
         failed = sum(1 for check in checks if check.get("bucket") == "fail")
         if failed:
             print("CHECKS_DONE_WITH_FAILURES", flush=True)
-        else:
+        elif passed:
             print("ALL_CHECKS_PASSED", flush=True)
+        else:
+            print("CHECKS_DONE_WITH_FAILURES", flush=True)
 
         print_check_summary(checks)
         return 0

--- a/skills/iterate-pr/scripts/monitor_pr_checks.py
+++ b/skills/iterate-pr/scripts/monitor_pr_checks.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# ///
+"""
+Monitor PR checks until they reach a terminal state.
+
+Usage:
+    uv run monitor_pr_checks.py [--pr PR_NUMBER]
+
+If --pr is not specified, uses the PR for the current branch.
+
+Output:
+    - Prints `ALL_CHECKS_PASSED` when all checks finish without failures
+    - Prints `CHECKS_DONE_WITH_FAILURES` when checks finish with failures
+    - Prints a tab-separated check summary after the terminal marker
+
+The script stays quiet while polling so background monitor tools do not emit
+unnecessary notifications on every iteration. Transient `gh` failures are
+retried instead of terminating the monitor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def run_gh_json(args: list[str]) -> list[dict[str, Any]] | dict[str, Any] | None:
+    """Run a gh command that returns JSON."""
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+
+    if not result.stdout.strip():
+        return None
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def get_pr_number(pr_number: int | None) -> int | None:
+    """Resolve the PR number to monitor."""
+    if pr_number is not None:
+        return pr_number
+
+    pr_info = run_gh_json(["pr", "view", "--json", "number"])
+    if not isinstance(pr_info, dict):
+        return None
+
+    number = pr_info.get("number")
+    return number if isinstance(number, int) else None
+
+
+def get_checks(pr_number: int) -> list[dict[str, Any]] | None:
+    """Fetch the current check list for a PR."""
+    checks = run_gh_json([
+        "pr",
+        "checks",
+        str(pr_number),
+        "--json",
+        "name,bucket,link",
+    ])
+    return checks if isinstance(checks, list) else None
+
+
+def print_check_summary(checks: list[dict[str, Any]], max_lines: int = 20) -> None:
+    """Print a concise tab-separated check summary."""
+    for check in checks[:max_lines]:
+        name = str(check.get("name", "unknown"))
+        bucket = str(check.get("bucket", "unknown"))
+        link = str(check.get("link", ""))
+        print(f"{name}\t{bucket}\t{link}".rstrip(), flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Monitor PR checks until they finish")
+    parser.add_argument("--pr", type=int, help="PR number (defaults to current branch PR)")
+    parser.add_argument(
+        "--poll-seconds",
+        type=int,
+        default=30,
+        help="Polling interval while checks are pending or gh is transiently failing",
+    )
+    parser.add_argument(
+        "--no-checks-seconds",
+        type=int,
+        default=15,
+        help="Retry delay when a fresh push has not registered any checks yet",
+    )
+    args = parser.parse_args()
+
+    pr_number = get_pr_number(args.pr)
+    if pr_number is None:
+        print("No PR found for current branch", file=sys.stderr)
+        return 1
+
+    while True:
+        checks = get_checks(pr_number)
+        if checks is None:
+            time.sleep(args.poll_seconds)
+            continue
+
+        if not checks:
+            time.sleep(args.no_checks_seconds)
+            continue
+
+        pending = sum(1 for check in checks if check.get("bucket") == "pending")
+        if pending:
+            time.sleep(args.poll_seconds)
+            continue
+
+        failed = sum(1 for check in checks if check.get("bucket") == "fail")
+        if failed:
+            print("CHECKS_DONE_WITH_FAILURES", flush=True)
+        else:
+            print("ALL_CHECKS_PASSED", flush=True)
+
+        print_check_summary(checks)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/iterate-pr/scripts/monitor_pr_checks.py
+++ b/skills/iterate-pr/scripts/monitor_pr_checks.py
@@ -124,14 +124,11 @@ def main() -> int:
             time.sleep(args.poll_seconds)
             continue
 
-        passed = sum(1 for check in checks if check.get("bucket") == "pass")
         failed = sum(1 for check in checks if check.get("bucket") == "fail")
         if failed:
             print("CHECKS_DONE_WITH_FAILURES", flush=True)
-        elif passed:
-            print("ALL_CHECKS_PASSED", flush=True)
         else:
-            print("CHECKS_DONE_WITH_FAILURES", flush=True)
+            print("ALL_CHECKS_PASSED", flush=True)
 
         print_check_summary(checks)
         return 0

--- a/skills/skill-writer/SOURCES.md
+++ b/skills/skill-writer/SOURCES.md
@@ -17,7 +17,7 @@ This file tracks source material synthesized into `skill-writer`, plus iterative
 2. Source breadth is the primary quality lever; synthesis cannot stop early on limited samples.
 3. Provenance is stored in `SOURCES.md`, not SKILL header comments.
 4. Case-study style examples are required for deeper, reusable synthesis outcomes.
-5. Path guidance in `skill-writer` is agent-generic (no Claude-only root assumptions in workflow docs).
+5. Path guidance in `skill-writer` follows repository prior art: avoid host-specific absolute paths, but keep established root variables such as `${CLAUDE_SKILL_ROOT}` when the workspace already standardizes on them.
 6. Skill placement defaults to `.agents/skills` unless workspace prior art establishes another location.
 
 ## Open gaps
@@ -29,6 +29,7 @@ This file tracks source material synthesized into `skill-writer`, plus iterative
 
 - 2026-03-05: Initialized `SOURCES.md` with baseline source pack (local canonical, Codex upstream, Claude upstream, spec, and repo conventions).
 - 2026-03-19: Clarified path-resolution guidance so bundled skill references stay skill-root-relative while registration steps are resolved from the repository's active layout.
-- 2026-03-19: Made portability a default authoring rule and disallowed provider-specific path variables in generic skills.
+- 2026-03-19: Made portability a default authoring rule and emphasized avoiding host-specific absolute filesystem paths.
+- 2026-04-19: Updated path guidance to preserve repository-standard root variables such as `${CLAUDE_SKILL_ROOT}` instead of banning them outright.
 - 2026-04-19: Restored `.agents/skills` as the default authoring target and kept repository-specific layouts as an inspected override rather than the default.
 - 2026-04-19: Added explicit prior-art inspection and user-confirmation guidance when the correct skill root is unclear.

--- a/skills/skill-writer/references/authoring-path.md
+++ b/skills/skill-writer/references/authoring-path.md
@@ -18,8 +18,8 @@ Use this path to create or update the skill files.
 2. Prefer relative references in skill content even when the repository also exposes mirrored or symlinked paths.
 3. Reserve repo-root paths for repository registration instructions only (for example `README.md`, `.claude/settings.json`).
 4. If the repository has multiple visible layouts for the same skill tree, inspect the workspace and edit the canonical location rather than assuming one layout from a generic template.
-5. Do not use provider-specific path variables such as `${CLAUDE_SKILL_ROOT}` in skills that are meant to stay provider-agnostic; use skill-root-relative paths instead.
-6. Only keep provider-specific path conventions when the skill is intentionally provider-specific and that scope is made explicit.
+5. Follow repository prior art for bundled file paths. If the workspace already standardizes on a root variable such as `${CLAUDE_SKILL_ROOT}`, keep using it consistently instead of inventing a different path model.
+6. If the workspace does not have an established provider-specific convention, prefer skill-root-relative references such as `references/...`, `scripts/...`, and `assets/...`.
 
 ## Supporting files
 

--- a/skills/skill-writer/references/design-principles.md
+++ b/skills/skill-writer/references/design-principles.md
@@ -158,18 +158,19 @@ Run `uv run <skill-dir>/scripts/tool.py`.
 Treat portability as the default requirement for generated skills.
 
 - Prefer cross-agent wording such as "skill root", "repository root", and relative paths like `references/...` or `scripts/...`
-- Avoid provider-specific environment variables, directory names, or invocation contracts in skills that should remain provider-agnostic
-- Only introduce provider-specific instructions when the skill is intentionally scoped to that provider, and label that scope explicitly in the description and body
+- Avoid inventing provider-specific environment variables, directory names, or invocation contracts when the workspace does not already rely on them
+- Reuse established repository conventions such as `${CLAUDE_SKILL_ROOT}` when that is how bundled skill files are already addressed in the workspace
+- Only introduce new provider-specific instructions when the skill is intentionally scoped to that provider, and label that scope explicitly in the description and body
 
 ```markdown
-# Bad
-Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/check.py`
+# Bad (in a repo that already standardizes on `${CLAUDE_SKILL_ROOT}`)
+Run `uv run scripts/check.py`
 
 # Good
-Run `uv run scripts/check.py`
+Run `uv run ${CLAUDE_SKILL_ROOT}/scripts/check.py`
 ```
 
-If a host requires a special runtime variable or working-directory convention, document it as a compatibility note, not as the primary path model for the skill.
+If the workspace does not already establish a provider-specific root variable, prefer skill-root-relative references instead.
 
 ## Long Reference Files
 

--- a/skills/skill-writer/references/registration-validation.md
+++ b/skills/skill-writer/references/registration-validation.md
@@ -46,7 +46,7 @@ If you must run the validator from another working directory, convert both paths
 
 4. Confirm portability for skills that are expected to be portable by default:
 - bundled file references use skill-root-relative paths such as `references/...`, `scripts/...`, or `assets/...`
-- provider-specific path variables (for example `${CLAUDE_SKILL_ROOT}`) are absent unless the skill is intentionally provider-specific
+- provider-specific path variables (for example `${CLAUDE_SKILL_ROOT}`) either follow established repository prior art or are explicitly scoped, rather than being introduced ad hoc
 - provider-specific behavior, if any, is labeled as compatibility guidance rather than the primary workflow
 
 5. Confirm evaluation outputs as applicable:


### PR DESCRIPTION
Extract the iterate-pr monitor loop into a bundled script and update the skill docs to point at that script instead of embedding the polling behavior inline.

This follow-up also fixes `skill-writer`'s path guidance. The repo already standardizes on `${CLAUDE_SKILL_ROOT}` for bundled skill assets, so `skill-writer` should preserve that prior art instead of treating it as invalid by default.

Keeping the monitor behavior in `scripts/monitor_pr_checks.py` makes the CI-wait logic easier to maintain and keeps the Claude-only `MonitorTool` guidance tied to repo-shipped behavior instead of a markdown shell snippet.

Validated with `uv run skills/iterate-pr/scripts/monitor_pr_checks.py --help`, `uv run skills/skill-writer/scripts/quick_validate.py skills/iterate-pr --skill-class workflow-process --strict-depth`, and `uv run skills/skill-writer/scripts/quick_validate.py skills/skill-writer --skill-class skill-authoring --strict-depth`.