### PR TITLE
docs(prompt-optimizer): fill in three guidance gaps (#120, #121, #122)

### DIFF
--- a/skills/prompt-optimizer/SKILL.md
+++ b/skills/prompt-optimizer/SKILL.md
@@ -58,6 +58,7 @@ Read `references/core-patterns.md`.
 1. Separate durable behavior from task-local context:
 - stable policy and behavioral defaults belong in `system` or `developer`
 - variable inputs, retrieved context, and task instances belong in templated user-facing sections
+- when the system prompt is assembled at runtime from a platform layer and a deployer-authored persona layer (e.g., `SOUL.md`, `CLAUDE.md`, `AGENTS.md`), see "Layered prompts with multiple owners" in `references/core-patterns.md` — platform behavior rules must not depend on what the deployer layer contains
 
 2. Keep one authoritative instruction per behavior:
 - if a rule appears in more than one layer, choose one owner for it

--- a/skills/prompt-optimizer/references/core-patterns.md
+++ b/skills/prompt-optimizer/references/core-patterns.md
@@ -88,7 +88,7 @@ When prompts are long, separate policy from evidence explicitly:
 - instructions in one block
 - retrieved documents in another
 - examples in another
-- tool rules and schemas in their own labeled sections
+- tool policy (when/why/whether) in its own labeled section; tool schemas stay in the provider-native tools parameter
 
 For long-context prompts, place long evidence before the final query and keep the actual ask in a terminal section.
 Do not cargo-cult this ordering into short prompts that do not need it.

--- a/skills/prompt-optimizer/references/core-patterns.md
+++ b/skills/prompt-optimizer/references/core-patterns.md
@@ -27,6 +27,29 @@ Do not add markup around every sentence. Markers are useful when they carve the 
 
 If the target stack or model family responds better to plain markdown, use headings and bullets instead of XML-style tags. The structure matters more than the syntax.
 
+### Where rules live
+
+Markers signal to the model what kind of content a block carries. Descriptive
+or state markers (`<context>`, `<state>`, `<turn-state>`, `<environment>`,
+`<artifact-state>`) read as facts about the situation — data, not policy.
+Canonical rules markers (`<behavior>`, `<constraints>`, `<tool_policy>`,
+`<workflow>`) read as directives the model should follow.
+
+A directive buried in a descriptive block can underperform the same directive
+placed in a rules block, especially for state-conditional rules. Observed in
+the field: a resume-notice instruction placed inside `<turn-state>resumed</turn-state>`
+scored 0.5 on the relevant eval; the identical sentence moved into
+`<behavior>` passed at ≥0.75 with no other change.
+
+Rules of thumb:
+
+- keep descriptive markers descriptive — put facts about the situation there,
+  not directives
+- directives live in a canonical rules section
+- for state-conditional rules, phrase them in the rules section and reference
+  the state by name: "When `<turn-state>` is `resumed`, post a brief
+  continuation notice, then answer."
+
 ## Layer the prompt correctly
 
 Keep these layers separate:
@@ -171,6 +194,7 @@ Use markdown headings instead of tags if that fits the target stack better.
 - Keep progress-update style explicit if the user should see it.
 - Use the shortest wording that preserves the intended behavioral constraint.
 - Remove persona, motivation, or reminder text that does not change measured behavior.
+- Place directives in canonical rules sections (`<behavior>`, `<constraints>`, `<tool_policy>`, `<workflow>`), not buried inside descriptive markers like `<context>`, `<state>`, or `<turn-state>`.
 
 ## Examples
 

--- a/skills/prompt-optimizer/references/core-patterns.md
+++ b/skills/prompt-optimizer/references/core-patterns.md
@@ -70,6 +70,34 @@ When prompts are long, separate policy from evidence explicitly:
 For long-context prompts, place long evidence before the final query and keep the actual ask in a terminal section.
 Do not cargo-cult this ordering into short prompts that do not need it.
 
+### Layered prompts with multiple owners
+
+The layers above assume a single author owns the whole system prompt. Many
+runtimes concatenate the system prompt from multiple layers with different
+owners at request time:
+
+- a **platform layer** owned by the product or framework team (harness rules,
+  tool-use policy, output contract, safety boundaries)
+- a **deployer or persona layer** authored by the downstream user or customer
+  (voice, tone, identity files such as `SOUL.md`, `CLAUDE.md`, `AGENTS.md`)
+
+When this is the case, treat the deployer layer as **voice-only**:
+
+- every platform behavior rule — evidence gathering, tool-use policy, narration
+  rules, output contract, escalation boundaries — must live in the
+  platform-owned layer and must still fire if the deployer layer is empty,
+  five lines of voice, or customized in unexpected ways
+- do not delete a platform bullet on the assumption that a persona file
+  "probably covers it"; deployers ship sparse persona files in practice
+- if a rule is load-bearing, it belongs in the platform layer by default;
+  the deployer layer gets voice and domain framing, not policy
+
+Hermes Agent, OpenClaw, and similar SOUL.md-style frameworks use this split
+explicitly: platform behavior is code-level, SOUL.md carries identity and
+tone, and the platform falls back to a built-in default identity if SOUL.md
+is absent or sparse. Mirror that invariant whenever a prompt is assembled
+from more than one authorship layer.
+
 ## Portable agent prompt skeleton
 
 Use this as a starting point and adapt it.

--- a/skills/prompt-optimizer/references/core-patterns.md
+++ b/skills/prompt-optimizer/references/core-patterns.md
@@ -18,7 +18,7 @@ Good section names are concrete and stable:
 - `<role>`
 - `<goal>`
 - `<context>`
-- `<tools>`
+- `<tool_policy>`
 - `<workflow>`
 - `<constraints>`
 - `<output_format>`
@@ -72,7 +72,20 @@ Do not cargo-cult this ordering into short prompts that do not need it.
 
 ## Portable agent prompt skeleton
 
-Use this as a starting point and adapt it:
+Use this as a starting point and adapt it.
+
+Tool schemas are disclosed to the model by the provider-native tools parameter
+(Anthropic `tools`, OpenAI `tools`, Gemini `tools`). On Anthropic this is
+explicit — the API constructs a special system prompt that injects the tool
+definitions from the `tools` parameter alongside the user-authored system
+prompt. Well-tuned harnesses (Codex CLI, pi-agent-core) pass tools natively
+and keep the prompt text free of schema restatements.
+
+The prompt text should carry tool *policy* — when to call tools, when to avoid
+them, what evidence to gather before acting — not a restated list of tool
+names or argument schemas. Naming a specific tool in a policy rule ("prefer
+`Read` over a `Bash` cat") is fine; re-enumerating the tool inventory or its
+schemas is not.
 
 ```text
 <role>
@@ -91,11 +104,11 @@ Available files or documents:
 Known constraints:
 </context>
 
-<tools>
-Available tools:
-When to use them:
-When to avoid them:
-</tools>
+<tool_policy>
+When to use tools:
+When to avoid tools:
+Evidence to gather before acting:
+</tool_policy>
 
 <workflow>
 1. Clarify only if required.

--- a/skills/prompt-optimizer/references/model-family-notes.md
+++ b/skills/prompt-optimizer/references/model-family-notes.md
@@ -12,6 +12,7 @@ Use this file to adapt prompts to model behavior instead of assuming all model f
 - Use delimiters such as markdown headings, XML tags, or section titles when the prompt mixes multiple content blocks.
 - Try zero-shot first. Add few-shot examples only when the output contract or edge cases need them.
 - Be explicit about constraints, success criteria, and completion conditions.
+- Tool schemas are disclosed via the Responses API `tools` parameter. Keep tool policy (when/why/whether to call) in the prompt; do not restate tool names or argument schemas.
 
 ### GPT-style non-reasoning models
 
@@ -29,6 +30,7 @@ Use this file to adapt prompts to model behavior instead of assuming all model f
 - For long context, place long documents before the question and put the actual query near the end.
 - When grounding in long documents, asking for relevant quotes first can improve downstream analysis.
 - If tool use or progress-update behavior matters, specify it explicitly rather than assuming the model will infer it.
+- When you call the Messages API with `tools`, the API injects the tool definitions into a special system prompt automatically. Keep your user-authored system prompt focused on policy; put tool detail in each tool's `description` field rather than re-listing schemas in prose.
 
 ## Gemini
 
@@ -39,6 +41,7 @@ Use this file to adapt prompts to model behavior instead of assuming all model f
 - Use system instructions when the target runtime supports them.
 - Thinking is dynamic by default on modern Gemini thinking models; tune it only when latency or deeper reasoning warrants it.
 - Gemini long-context workflows can benefit from many-shot in-context learning when you have a large bank of representative examples.
+- Tool schemas are disclosed via the Gemini API `tools` (function declarations) parameter. Keep the prompt focused on tool policy; do not re-list function names or parameter schemas.
 
 ## Cross-family adapter rules
 

--- a/skills/prompt-optimizer/references/transformed-examples.md
+++ b/skills/prompt-optimizer/references/transformed-examples.md
@@ -127,3 +127,42 @@ Why it is better:
 - removes chain-of-thought demand
 - replaces absolute slogans with operational rules
 - turns style goals into specific output behavior
+
+## Example 4: Directive placement — state marker vs. rules section
+
+### Before
+
+```text
+<turn-state>resumed</turn-state>
+This turn continues from a prior checkpoint. Post a brief continuation
+notice (e.g., "Connected — continuing.") and then the resumed answer
+as a separate message.
+```
+
+The directive is buried inside a descriptive state marker. In the field,
+this variant scored 0.5 on the relevant LLM-judged eval — the model read
+the block as situational data and combined both messages into one.
+
+### After
+
+```text
+<turn-state>resumed</turn-state>
+
+<behavior>
+When `<turn-state>` is `resumed`, post a brief continuation notice
+("Connected — continuing.") first, then send the resumed answer as a
+separate message.
+</behavior>
+```
+
+Same rule, stronger placement. The state marker stays descriptive; the
+directive moves to the canonical rules section and references the state
+by name. In the same eval, this variant passed at ≥0.75 with no other
+change.
+
+Why it is better:
+
+- keeps descriptive markers descriptive — facts, not policy
+- places the directive where the model reads directives
+- makes the state-conditional nature explicit instead of implicit
+- preserves a single authoritative owner for the rule

--- a/skills/prompt-optimizer/references/transformed-examples.md
+++ b/skills/prompt-optimizer/references/transformed-examples.md
@@ -20,10 +20,10 @@ Implement the user's requested change end-to-end when feasible.
 Do not stop at analysis if you can safely gather facts and act.
 </goal>
 
-<tools>
+<tool_policy>
 Use tools to inspect the workspace before assuming facts.
 Read before write. Validate the changed surface before finishing.
-</tools>
+</tool_policy>
 
 <workflow>
 1. Restate the objective briefly.


### PR DESCRIPTION
Close three open enhancement issues on the `prompt-optimizer` skill by filling
gaps where the skill was either silent or actively nudging authors toward
weaker patterns. All edits land in the existing skill structure — no new
workflow steps, no new reference files.

## What changed

**#120 — tool policy vs. native tool disclosure**
- Renamed the `<tools>` marker to `<tool_policy>` in the portable skeleton,
  Example 1, and the canonical "good section names" list.
- Added a note in `core-patterns.md` and one line per provider section in
  `model-family-notes.md` clarifying that tool schemas are disclosed via the
  provider-native `tools` parameter (Anthropic, OpenAI, Gemini) — the prompt
  should carry policy, not schema restatements.
- Tightened the "Layer the prompt correctly" long-prompt bullet to match.

**#121 — layered prompts with multiple owners**
- New `### Layered prompts with multiple owners` subsection in
  `core-patterns.md` covering the platform-layer vs. deployer-persona-layer
  split (`SOUL.md`, `CLAUDE.md`, `AGENTS.md`).
- The invariant: the deployer layer is voice-only; platform behavior rules
  must still fire if the deployer layer is empty or sparse.
- Cross-reference added from `SKILL.md` Step 3.

**#122 — directives in descriptive markers**
- New `### Where rules live` subsection in `core-patterns.md` noting that
  descriptive markers (`<context>`, `<state>`, `<turn-state>`,
  `<environment>`) read as data and state-conditional directives buried
  in them can underperform the same directive in a canonical rules section
  (`<behavior>`, `<constraints>`, `<tool_policy>`, `<workflow>`).
- New bullet in "High-value prompt moves".
- New `## Example 4` in `transformed-examples.md` with the resume-notice
  before/after (0.5 → ≥0.75 on the relevant eval with no other change).

## Why

Each issue came with a concrete field finding. The skill was either silent
on the topic (#121 layered prompts, #122 rule placement) or actively nudging
authors toward the weaker pattern (#120 enumerating tools in the prompt).
The edits keep the skill's "empirical finding → rule" voice and stay inside
the existing file structure.

## Prior art consulted

Rather than rely purely on the field observations in the issues, I checked
authoritative sources for each claim:

- [Anthropic tool-use docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview):
  "When you call the Claude API with the tools parameter, the API constructs
  a special system prompt from the tool definitions, tool configuration, and
  any user-specified system prompt" — schemas are injected automatically.
- [pi-agent-core](https://github.com/badlogic/pi-mono) `packages/agent/src/agent-loop.ts`:
  LLM is invoked with `llmContext = { systemPrompt, messages, tools }` — tools
  are a distinct native parameter alongside prompt text.
- [OpenAI Codex CLI system prompt](https://github.com/openai/codex/blob/main/codex-rs/core/gpt-5.1-codex-max_prompt.md):
  references tools contextually as policy ("prefer `rg` for searching") and
  does not restate schemas.
- [Hermes Agent SOUL.md](https://hermes-agent.nousresearch.com/docs/user-guide/features/personality)
  and [soul-md.xyz](https://www.soul-md.xyz/): direct industry prior art for
  the platform + persona layering model (SOUL.md for voice, AGENTS.md for
  project, platform defaults code-level). Hermes explicitly falls back to a
  built-in default identity when SOUL.md is empty — the pattern the skill
  now documents.

Notably, Codex and Claude Code system prompts both do embed directives in
descriptive sections in places, so the #122 guidance is scoped to
state-conditional rules where the author's eval showed a measurable gap,
not an absolute rule against context-section prose.

Fixes #120
Fixes #121
Fixes #122