### PR TITLE
ref(skills): Enforce skill independence

### DIFF
--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -15,15 +15,7 @@ Before committing, always check the current branch:
 git branch --show-current
 ```
 
-**If you're on `main` or `master`, you MUST create a feature branch first** — unless the user explicitly asked to commit to main. Do not ask the user whether to create a branch; just proceed with branch creation. The `create-branch` skill should derive and create a suitable branch name automatically.
-
-Use the `create-branch` skill to create the branch. After `create-branch` completes, verify the current branch has changed before proceeding:
-
-```bash
-git branch --show-current
-```
-
-If still on `main` or `master`, stop — do not commit.
+**If you're on `main` or `master`, you MUST create a feature branch first** — unless the user explicitly asked to commit to main. Do not ask the user whether to create a branch; just proceed with branch creation, then re-check the current branch before committing. If still on `main` or `master`, stop — do not commit.
 
 ## Format
 

--- a/skills/pr-writer/SKILL.md
+++ b/skills/pr-writer/SKILL.md
@@ -11,14 +11,14 @@ Create pull requests following Sentry's engineering practices.
 
 ## Prerequisites
 
-Before creating a PR, ensure all changes are committed. If there are uncommitted changes, run the `sentry-skills:commit` skill first to commit them properly.
+Before creating a PR, ensure all changes are committed.
 
 ```bash
 # Check for uncommitted changes
 git status --porcelain
 ```
 
-If the output shows any uncommitted changes (modified, added, or untracked files that should be included), invoke the `sentry-skills:commit` skill before proceeding.
+If the output shows any uncommitted changes (modified, added, or untracked files that should be included), commit them before proceeding.
 
 ## Process
 

--- a/skills/pr-writer/SKILL.md
+++ b/skills/pr-writer/SKILL.md
@@ -11,14 +11,15 @@ Create pull requests following Sentry's engineering practices.
 
 ## Prerequisites
 
-Before creating a PR, ensure all changes are committed.
+Before creating a PR, ensure all changes are committed **to a feature branch**, not to the default branch.
 
 ```bash
-# Check for uncommitted changes
+# Check current branch and for uncommitted changes
+git branch --show-current
 git status --porcelain
 ```
 
-If the output shows any uncommitted changes (modified, added, or untracked files that should be included), commit them before proceeding.
+If on `main` or `master`, create a feature branch and move any uncommitted changes onto it before committing — a PR cannot be opened from the default branch against itself. If there are uncommitted changes, commit them on the feature branch before proceeding.
 
 ## Process
 

--- a/skills/skill-writer/EVAL.md
+++ b/skills/skill-writer/EVAL.md
@@ -6,7 +6,7 @@ These are optional guidance artifacts, not required outputs for every skill.
 ## Integration/Documentation Depth Eval
 
 ```text
-Use `sentry-skills:skill-writer` to synthesize a new skill named `pi-agent-integration-eval` for working with `@mariozechner/pi-agent-core` as a consumer in downstream libraries.
+Synthesize a new skill named `pi-agent-integration-eval` for working with `@mariozechner/pi-agent-core` as a consumer in downstream libraries.
 
 Primary objective: produce a non-surface-level integration skill that covers API surface, known issues/workarounds, and common real-world use cases.
 

--- a/skills/skill-writer/references/design-principles.md
+++ b/skills/skill-writer/references/design-principles.md
@@ -117,6 +117,18 @@ Pick one term for each concept and use it throughout the skill. Inconsistent ter
 | "field" everywhere | "field", "box", "element", "control" |
 | "extract" everywhere | "extract", "pull", "get", "retrieve" |
 
+## Independence
+
+A skill must never reference another skill. Do not name another skill in SKILL.md or its references — not as an instruction (`run the X skill`, `use \`sentry-skills:Y\``, `hand off to Z`), not as a "see also", and not by path (`skills/other-skill/...`). Other skills may not be installed, may be renamed, or may be overridden by a user's own skill of the same name; any named reference silently breaks in all three cases.
+
+State the intent directly and trust the agent's skill discovery to pick up whatever skill matches:
+
+| Do | Don't |
+|----|-------|
+| "If you're on `main`, create a feature branch first." | "Use the `create-branch` skill to create the branch." |
+| "If there are uncommitted changes, commit them first." | "Run the `sentry-skills:commit` skill before proceeding." |
+| "For deeper guidance on X, see `references/x.md`." | "See the `other-skill` skill for X." |
+
 ## Avoid Duplication
 
 Information should live in either SKILL.md or reference files, not both. Prefer reference files for detailed content and SKILL.md for the core procedural workflow.

--- a/skills/skill-writer/references/design-principles.md
+++ b/skills/skill-writer/references/design-principles.md
@@ -119,7 +119,7 @@ Pick one term for each concept and use it throughout the skill. Inconsistent ter
 
 ## Independence
 
-A skill must never reference another skill. Do not name another skill in SKILL.md or its references — not as an instruction (`run the X skill`, `use \`sentry-skills:Y\``, `hand off to Z`), not as a "see also", and not by path (`skills/other-skill/...`). Other skills may not be installed, may be renamed, or may be overridden by a user's own skill of the same name; any named reference silently breaks in all three cases.
+A skill's runtime behavior must not depend on another skill being present. Do not instruct the agent to invoke another skill by name (`run the X skill`, `use \`sentry-skills:Y\``, `hand off to Z`), and do not treat another skill's files as runtime resources (`load skills/other-skill/references/foo.md`). Other skills may not be installed, may be renamed, or may be overridden by a user's own skill of the same name; any runtime dependency silently breaks in all three cases.
 
 State the intent directly and trust the agent's skill discovery to pick up whatever skill matches:
 
@@ -128,6 +128,8 @@ State the intent directly and trust the agent's skill discovery to pick up whate
 | "If you're on `main`, create a feature branch first." | "Use the `create-branch` skill to create the branch." |
 | "If there are uncommitted changes, commit them first." | "Run the `sentry-skills:commit` skill before proceeding." |
 | "For deeper guidance on X, see `references/x.md`." | "See the `other-skill` skill for X." |
+
+Mentioning another skill's name in non-runtime content — provenance logs, audit allowlists, eval prompts meant to be copy-pasted by a human — is fine. The rule targets runtime behavior, not any mention of a skill's name.
 
 ## Avoid Duplication
 


### PR DESCRIPTION
Remove named cross-skill invocations from the `commit` and `pr-writer` skills, and add an Independence principle to `skill-writer/references/design-principles.md` so future skills are authored the same way.

**Why.** Skills that name another skill in their runtime instructions silently break in three ways: the named skill may not be installed, it may be renamed, or it may be overridden by a user's own skill of the same name. `commit` pointed at `create-branch`; `pr-writer` pointed at `sentry-skills:commit`. Both now state the intent directly and trust skill discovery to pick up whatever matches.

**Scope of the principle.** The rule targets *runtime dependency*: agent-facing instructions and loaded resources must not assume another skill is present. Non-runtime mentions — provenance logs, audit allowlists, human-facing eval prompts — are fine. `claude-settings-audit` enumerates every skill name because that is its job, and `prompt-optimizer/SOURCES.md` cites `skill-writer` as a synthesis source; both are intentional exceptions carved out in the principle's text.

**What changed.**
- `skills/commit/SKILL.md` — drop `create-branch` references; keep the "branch off main/master first" requirement inline.
- `skills/pr-writer/SKILL.md` — drop `sentry-skills:commit` references; keep the "commit first" requirement inline.
- `skills/skill-writer/references/design-principles.md` — add an Independence section with do/don't examples and the runtime-scope carve-out.
- `skills/skill-writer/EVAL.md` — remove the `sentry-skills:skill-writer` self-reference from the sample eval prompt.