### PR TITLE
feat(skill-writer): Add skill specs and evidence guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Skill Structure
 ```
 skills/<skill-name>/SKILL.md
+skills/<skill-name>/SPEC.md
 ```
 
 If you use Claude marketplace sparse checkouts for this repo, include `skills` and `agents` alongside `.claude-plugin` because the root plugin manifest loads repo-root `skills/` and `agents/`.
@@ -16,9 +17,10 @@ ALWAYS use `/skill-writer` — it handles requirements, writing, registration, a
 
 ### Registration Checklist
 1. Create `skills/<skill-name>/SKILL.md`
-2. Add to `README.md` Available Skills table (alphabetical by canonical skill name; exclude aliases/symlinks)
-3. Add to `.claude/settings.json`: `Skill(sentry-skills:<skill-name>)`
-4. Add to allowlist in `skills/claude-settings-audit/SKILL.md`
+2. Create `skills/<skill-name>/SPEC.md`
+3. Add to `README.md` Available Skills table (alphabetical by canonical skill name; exclude aliases/symlinks)
+4. Add to `.claude/settings.json`: `Skill(sentry-skills:<skill-name>)`
+5. Add to allowlist in `skills/claude-settings-audit/SKILL.md`
 
 ## Key Conventions
 - Frontmatter `---` must be the **first line** of SKILL.md — no comments before it
@@ -27,6 +29,7 @@ ALWAYS use `/skill-writer` — it handles requirements, writing, registration, a
 - Attribution comments go **after** the closing `---`
 - Python scripts: always use `uv run <script>`, never `python` or `python3`
 - Keep SKILL.md under 500 lines; move reference material to `references/`
+- Keep runtime instructions in `SKILL.md`; put intent, source/evidence model, evaluation, limitations, and maintenance rules in `SPEC.md`
 
 ## Commit Attribution
 AI commits MUST include:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ sentry-skills/
 The canonical skill source for the `sentry-skills` plugin lives at repo-root `skills/`.
 `.agents/skills` mirrors that tree for local agent tooling, and the root plugin manifest loads repo-root `skills/` and `agents/`.
 
+New skills and materially changed skills should include a root-level `SPEC.md` alongside `SKILL.md`.
+
 ### Creating New Skills
 
 Skills follow the [Agent Skills specification](https://agentskills.io/specification). Each skill requires a `SKILL.md` file with YAML frontmatter.
@@ -123,7 +125,8 @@ Create a new directory under `skills/`:
 
 ```
 skills/my-skill/
-└── SKILL.md
+├── SKILL.md
+└── SPEC.md
 ```
 
 **SKILL.md format:**
@@ -149,6 +152,10 @@ Concrete examples showing expected input/output.
 - Specific rules to follow
 - Edge cases to handle
 ```
+
+**SPEC.md format:**
+
+Use `SPEC.md` as the maintenance contract for the skill. It should describe intent, scope, trigger context, source/evidence model, reference architecture, evaluation expectations, known limitations, and maintenance notes. Keep runtime instructions in `SKILL.md`; keep source inventories in `SOURCES.md`; keep durable examples in `references/evidence/`.
 
 #### Naming Conventions
 

--- a/skills/skill-writer/EVAL.md
+++ b/skills/skill-writer/EVAL.md
@@ -21,10 +21,8 @@ Mandatory source retrieval:
 - In-repo usage scan for key APIs (for example Agent, agentLoop, streamProxy, convertToLlm, transformContext, steer, followUp, continue)
 
 Required depth artifacts:
-- `references/api-surface.md`
-- `references/common-use-cases.md` (at least 6 concrete downstream use cases)
-- `references/troubleshooting-workarounds.md` (at least 8 failure modes with fixes/workarounds)
-- `references/integration-patterns.md` (happy path, robust variant, anti-pattern + correction)
+- focused references covering API surface, at least 6 concrete downstream use cases, and at least 8 failure modes with fixes/workarounds
+- a focused integration-patterns or examples reference with happy path, robust variant, and anti-pattern + correction
 
 Depth gates (hard fail if missing):
 - Coverage matrix includes: API surface, options/config, runtime lifecycle, event semantics, queue semantics, failure modes, version variance, downstream usage patterns.

--- a/skills/skill-writer/SKILL.md
+++ b/skills/skill-writer/SKILL.md
@@ -14,15 +14,19 @@ Load only the path(s) required for the task:
 |------|------|
 | Set skill class and required dimensions | `references/mode-selection.md` |
 | Apply writing constraints for depth vs concision | `references/design-principles.md` |
+| Decide what belongs in SKILL.md vs reference files | `references/reference-architecture.md` |
+| Create or update a skill maintenance specification | `references/spec-template.md` |
 | Select structure pattern for this skill | `references/skill-patterns.md` |
 | Select workflow orchestration pattern for process-heavy skills | `references/workflow-patterns.md` |
 | Select output format pattern for deterministic quality | `references/output-patterns.md` |
 | Choose workflow path and required outputs | `references/mode-selection.md` |
+| Find high-signal source material, including history | `references/source-discovery.md` |
 | Load representative synthesis examples by skill type | `references/examples/*.md` |
 | Synthesize external/local sources with depth gates | `references/synthesis-path.md` |
 | Author or update SKILL.md and supporting files | `references/authoring-path.md` |
 | Optimize skill description and trigger precision | `references/description-optimization.md` |
 | Iterate using positive/negative/fix examples | `references/iteration-path.md` |
+| Store improvement evidence for future iterations | `references/iteration-evidence.md` |
 | Evaluate behavior and compare baseline vs with-skill (opt-in quantitative) | `references/evaluation-path.md` |
 | Register and validate skill changes | `references/registration-validation.md` |
 
@@ -50,20 +54,22 @@ Load only the path(s) required for the task:
 Read `references/synthesis-path.md`.
 
 1. Collect and score relevant sources with provenance.
-2. Apply trust and safety rules when ingesting external content.
-3. Produce source-backed decisions and coverage/gap status.
-4. Load one or more profiles from `references/examples/*.md` when the skill is hybrid.
-5. Enforce baseline source pack for skill-authoring workflows.
-6. Enforce depth gates before moving to authoring.
+2. Read `references/source-discovery.md` when source material is thin, stale, or ambiguous.
+3. Apply trust and safety rules when ingesting external content.
+4. Produce source-backed decisions and coverage/gap status.
+5. Load one or more profiles from `references/examples/*.md` when the skill is hybrid.
+6. Enforce baseline source pack for skill-authoring workflows.
+7. Enforce depth gates before moving to authoring.
 
 ## Step 3: Run iteration first when improving from outcomes/examples
 
 Read `references/iteration-path.md` first when selected path includes `iteration` (for example operation `iterate`).
 
 1. Capture and anonymize examples with provenance.
-2. Re-evaluate skill behavior against working and holdout slices.
-3. Propose improvements from positive/negative/fix evidence.
-4. Carry concrete behavior deltas into authoring.
+2. Read `references/iteration-evidence.md` when examples should persist beyond the current turn.
+3. Re-evaluate skill behavior against working and holdout slices.
+4. Propose improvements from positive/negative/fix evidence.
+5. Carry concrete behavior deltas into authoring.
 
 Skip this step when selected path does not include `iteration`.
 
@@ -72,10 +78,12 @@ Skip this step when selected path does not include `iteration`.
 Read `references/authoring-path.md`.
 
 1. Write or update `SKILL.md` in imperative voice with trigger-rich description.
-2. Create focused reference files and scripts only when justified.
-3. Follow `references/skill-patterns.md`, `references/workflow-patterns.md`, and
+2. Read `references/reference-architecture.md` before adding bulk instructions or new reference files.
+3. Create or update `SPEC.md` using `references/spec-template.md` when creating a new skill or materially changing an existing skill's intent, sources, evaluation, or maintenance model.
+4. Create focused reference files and scripts only when justified.
+5. Follow `references/skill-patterns.md`, `references/workflow-patterns.md`, and
    `references/output-patterns.md` for structure and output determinism.
-4. For authoring/generator skills, include transformed examples in references:
+6. For authoring/generator skills, include transformed examples in references:
    - happy-path
    - secure/robust variant
    - anti-pattern + corrected version

--- a/skills/skill-writer/SOURCES.md
+++ b/skills/skill-writer/SOURCES.md
@@ -8,7 +8,19 @@ This file tracks source material synthesized into `skill-writer`, plus iterative
 |---|---|---|---|---|---|---|---|
 | `SKILL.md` | local canonical | canonical | 2026-04-19 | high | Baseline orchestration, path model, quality gates | local active skill root | Primary source of current behavior |
 | `references/*.md` | local canonical | canonical | 2026-04-19 | high | Detailed path guidance, examples, validation requirements | local active skill root | Includes synthesis/iteration/evaluation paths |
+| `SPEC.md` | local canonical | canonical | 2026-04-26 | high | Canonical maintenance contract example for skill intent, scope, evidence model, evaluation, and limitations | local active skill root | Added as the reference implementation for future skill specs |
 | `https://agentskills.io/specification` | external canonical spec | canonical | 2026-03-05 | high | Portable skill spec requirements | spec-level constraints take precedence over local preferences | Cross-agent compatibility baseline |
+| `https://agentskills.io/specification` | external canonical spec | canonical | 2026-04-26 | high | Confirms optional `scripts/`, `references/`, and `assets/`; focused references; progressive disclosure; one-level file references | spec-level constraints take precedence over local preferences | Re-reviewed for reference architecture update |
+| `https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices` | external official docs | canonical | 2026-04-26 | high | Concise SKILL.md guidance, split files near 500 lines, one-level references, table of contents for long references, real-usage iteration | Claude-specific examples generalized only when compatible with Agent Skills spec | Re-reviewed for reference architecture and iteration evidence update |
+| `https://platform.openai.com/docs/guides/prompt-engineering` | external official docs | canonical | 2026-04-26 | high | Reinforces diverse examples and eval-backed prompt iteration | product-specific examples may evolve; use as general prompt/eval guidance | Redirects to current OpenAI developer docs |
+| `https://platform.openai.com/docs/guides/evals` | external official docs | canonical | 2026-04-26 | high | Reinforces eval-first iteration loop: define task, run test inputs, analyze results, improve prompt | product-specific eval API details may evolve | Used to shape working/holdout evidence guidance |
+| `https://learn.microsoft.com/en-us/agent-framework/agents/skills` | external implementation docs | secondary | 2026-04-26 | medium | Confirms broad Agent Skills packaging model and optional directories | implementation-specific; lower priority than Agent Skills spec | Cross-check for portability assumptions |
+| `https://huggingface.co/docs/hub/model-cards` | external documentation pattern | secondary | 2026-04-26 | high | Model-card sections for intended use, data, evaluation, limitations, and reproducibility | adapted as documentation prior art, not a skill standard | Inspired `SPEC.md` maintenance contract shape |
+| `https://huggingface.co/docs/hub/en/model-card-annotated` | external documentation pattern | secondary | 2026-04-26 | high | Annotated intended-use, out-of-scope, risks, limitations, and evaluation sections | adapted as documentation prior art, not a skill standard | Informed SPEC scope and limitations sections |
+| `https://cacm.acm.org/research/datasheets-for-datasets/` | research/documentation pattern | secondary | 2026-04-26 | high | Data provenance, collection, composition, intended use, and maintenance transparency | adapted from dataset documentation to skill evidence documentation | Informed source/evidence model and privacy rules |
+| `https://diataxis.fr/` | documentation framework | secondary | 2026-04-26 | high | User-need-centered documentation types: tutorial, how-to, reference, explanation | adapted as information architecture prior art, not a skill standard | Informed reference files as lookup needs rather than topic buckets |
+| `https://dita-lang.org/` | documentation standard | secondary | 2026-04-26 | high | Topic-oriented technical content patterns: task, concept, reference, troubleshooting | adapted as documentation architecture prior art | Informed reference type table and troubleshooting matrix guidance |
+| `https://www.writethedocs.org/guide/writing/docs-principles/` | documentation guidance | secondary | 2026-04-26 | medium | Documentation should be structured for findability, reuse, and user participation | general writing guidance | Cross-check for reference architecture usability |
 | `AGENTS.md` | repo convention | canonical | 2026-03-05 | high | Repository-specific workflow requirements | repository-local policy | Registration + validator expectations |
 | `README.md` | repo convention | canonical | 2026-03-05 | high | Skill table format and authoring conventions | repository-local policy | Registration and discoverability source |
 
@@ -19,11 +31,33 @@ This file tracks source material synthesized into `skill-writer`, plus iterative
 4. Case-study style examples are required for deeper, reusable synthesis outcomes.
 5. Path guidance in `skill-writer` follows repository prior art: avoid host-specific absolute paths, but keep established root variables such as `${CLAUDE_SKILL_ROOT}` when the workspace already standardizes on them.
 6. Skill placement defaults to `.agents/skills` unless workspace prior art establishes another location.
+7. `SKILL.md` should remain an orchestration/index layer; detailed examples, source findings, rubrics, and domain facts belong in focused references.
+8. Persistent iteration evidence should live under `references/evidence/` with working and holdout examples separated, while decisions and changelog entries remain in `SOURCES.md`.
+9. Commit logs are an explicit source-discovery path for behavior that docs do not reveal, especially regressions, reversions, migrations, and hard-won edge cases.
+10. `SPEC.md` is the root-level maintenance contract for a skill, modeled after model-card and dataset-documentation prior art but scoped to agent-skill intent, sources, evidence, evaluation, limitations, and maintenance.
+11. Integration/documentation skills require coverage depth, not fixed reference filenames. The validator should warn on long references instead of enforcing specific reference file names.
+12. Reference files should be named and split by lookup need: decision, task, fact lookup, concept, troubleshooting, examples, or evaluation. Generic buckets such as "common use cases" are too vague unless the skill has a concrete lookup reason for them.
+
+## Coverage matrix
+
+| Dimension | Coverage status | Evidence |
+|---|---|---|
+| SKILL.md vs references placement | complete | Agent Skills spec, Claude best practices, local design principles |
+| Reference splitting heuristics | complete | Claude one-level reference guidance, local skill patterns |
+| Long reference navigation | complete | Claude table-of-contents guidance, local design principles |
+| Source discovery beyond docs | complete | local synthesis depth gates, repository history practices |
+| Commit log as source material | complete | local source-discovery guidance added from observed repo workflow needs |
+| Positive/negative evidence storage | complete | Claude real-usage iteration guidance, OpenAI eval iteration guidance, local iteration path |
+| Working vs holdout examples | complete | OpenAI eval loop guidance, local evaluation path |
+| Skill maintenance specification | complete | model cards, datasheets, local `SPEC.md` reference implementation |
+| Flexible reference names and length warnings | complete | local validator behavior and reference architecture guidance |
+| Lookup-oriented reference architecture | complete | Diataxis user needs, DITA topic types, local reference architecture |
 
 ## Open gaps
 
 1. Anthropic upstream source should be periodically re-reviewed for changes and recorded here with new retrieval dates.
 2. Add concrete example `SOURCES.md` files in synthesized skills to demonstrate expected depth in practice.
+3. Consider adding validator checks for oversized catch-all references if future generated skills keep overloading single files.
 
 ## Changelog
 
@@ -33,3 +67,7 @@ This file tracks source material synthesized into `skill-writer`, plus iterative
 - 2026-04-19: Updated path guidance to preserve repository-standard root variables such as `${CLAUDE_SKILL_ROOT}` instead of banning them outright.
 - 2026-04-19: Restored `.agents/skills` as the default authoring target and kept repository-specific layouts as an inspected override rather than the default.
 - 2026-04-19: Added explicit prior-art inspection and user-confirmation guidance when the correct skill root is unclear.
+- 2026-04-26: Added reference architecture, source discovery, and iteration evidence guidance; updated synthesis, authoring, and iteration paths to prevent overloaded `SKILL.md` and catch-all reference files.
+- 2026-04-26: Added `SPEC.md` as the canonical `skill-writer` maintenance specification and added `references/spec-template.md` for future skills.
+- 2026-04-26: Removed fixed integration reference filename validation and added length-based reference warnings.
+- 2026-04-26: Reworked reference architecture around concrete lookup needs instead of generic topic buckets.

--- a/skills/skill-writer/SPEC.md
+++ b/skills/skill-writer/SPEC.md
@@ -1,0 +1,130 @@
+# Skill Writer Specification
+
+## Intent
+
+`skill-writer` is the canonical workflow for creating, updating, synthesizing, and iteratively improving agent skills in this repository.
+
+Its primary purpose is to prevent shallow skill authoring by forcing high-value source coverage, explicit provenance, focused runtime instructions, and validation before completion.
+
+## Scope
+
+In scope:
+
+- New skill creation from local, external, or mixed sources.
+- Existing skill updates that affect runtime behavior, structure, trigger precision, references, or validation.
+- Research-first synthesis for proposed skills.
+- Iteration from positive examples, negative examples, review feedback, eval results, and observed agent behavior.
+- Registration and validation for this repository's canonical `skills/<skill-name>/` layout and other discovered layouts.
+
+Out of scope:
+
+- Acting as the runtime instructions for the skills it creates.
+- Storing full source inventories, raw examples, or changelog history directly in `SKILL.md`.
+- Replacing repository-level instructions in `AGENTS.md`, `README.md`, or `CONTRIBUTING.md`.
+- Creating per-skill aliases or symlink skills in this repository.
+- Guaranteeing compatibility with provider-specific skill extensions unless they are explicitly scoped and documented.
+
+## Users And Trigger Context
+
+- Primary users: agents and humans authoring or maintaining reusable agent skills.
+- Common user requests: "create a skill", "write a skill", "update this skill", "improve from examples", "synthesize a skill from docs", "maintain skill docs", or "validate/register this skill".
+- Should not trigger for: ordinary code review, generic documentation edits, PR writing, commit creation, or implementation work that does not create or modify an agent skill.
+
+## Runtime Contract
+
+- Required first actions:
+  - Resolve the target skill root and operation.
+  - Inspect local repository conventions before deciding where files belong.
+  - Classify the skill and select the minimum required workflow paths.
+- Required outputs:
+  - Summary.
+  - Changes Made.
+  - Validation Results.
+  - Open Gaps.
+- Non-negotiable constraints:
+  - `SKILL.md` frontmatter is first line and `name` matches the directory.
+  - `description` contains realistic trigger language.
+  - `SKILL.md` remains an orchestration/index layer for complex skills.
+  - Supporting references are focused and loaded conditionally.
+  - Source provenance and decisions live in `SOURCES.md`.
+  - Durable positive/negative examples live in `references/evidence/`.
+  - `SPEC.md` records the maintenance contract for new or materially changed skills.
+  - Validation runs before completion.
+- Expected bundled files loaded at runtime:
+  - `references/mode-selection.md`
+  - `references/synthesis-path.md`
+  - `references/iteration-path.md`
+  - `references/authoring-path.md`
+  - `references/reference-architecture.md`
+  - `references/spec-template.md`
+  - `references/description-optimization.md`
+  - `references/evaluation-path.md`
+  - `references/registration-validation.md`
+  - `scripts/quick_validate.py`
+
+## Source And Evidence Model
+
+Authoritative sources:
+
+- Local `skill-writer` runtime files: `SKILL.md`, `references/*.md`, `scripts/quick_validate.py`.
+- Repository policy: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, plugin manifests, and registration settings.
+- Agent Skills specification and official skill authoring guidance.
+
+Useful improvement sources:
+
+- positive examples: successful generated skills, review-approved skill changes, and eval passes that demonstrate desired behavior
+- negative examples: shallow generated skills, overloaded `SKILL.md` files, catch-all references, missing provenance, failed validation, false triggers, or review feedback
+- commit logs/changelogs: repeated fixes, reversions, migrations, and changes that explain why a rule exists
+- issue or PR feedback: reviewer comments about missing coverage, confusing trigger language, poor file placement, or insufficient evaluation
+- eval results: fixed prompt sets in `EVAL.md`, qualitative depth checks, and optional baseline-vs-with-skill runs
+
+Data that must not be stored:
+
+- secrets, credentials, or tokens
+- raw customer data
+- private URLs or identifiers that are not needed for reproduction
+- large copied source documents or long copyrighted excerpts
+- unredacted personal data from examples, logs, issues, or commits
+
+## Reference Architecture
+
+- `SKILL.md` contains the top-level workflow, path-loading table, branch points, universal constraints, and output contract.
+- `SPEC.md` contains this maintenance specification.
+- `SOURCES.md` contains source inventory, decisions, coverage matrix, open gaps, and changelog.
+- `EVAL.md` contains reusable evaluation prompts and deeper eval runbooks.
+- `references/` contains focused workflow guidance, patterns, templates, rubrics, and class-specific authoring requirements.
+- `references/evidence/` contains durable positive/negative examples when future iterations need them.
+- `scripts/` contains validation automation.
+- `assets/` is unused unless a future skill-authoring workflow needs static templates or media.
+
+## Evaluation
+
+- Lightweight validation:
+  - Run `uv run skills/skill-writer/scripts/quick_validate.py skills/skill-writer --skill-class skill-authoring --strict-depth`.
+  - Inspect changed references for focused scope, direct discoverability, and absence of host-specific paths.
+- Deeper evaluation:
+  - Use `EVAL.md` when a change affects synthesis depth gates, artifact requirements, or generated skill quality.
+  - Compare behavior before and after changes with representative positive and negative prompts.
+- Holdout examples:
+  - Keep durable holdout examples in `references/evidence/holdout-set.md` when repeated regressions appear.
+  - Do not tune directly against holdout examples until they are intentionally moved to the working set.
+- Acceptance gates:
+  - Validator passes with no errors.
+  - New or changed workflow rules are represented in the correct artifact.
+  - `SOURCES.md` records source-backed decisions and any remaining gaps.
+  - `SPEC.md` is updated when intent, scope, evidence model, evaluation, or maintenance expectations change.
+
+## Known Limitations
+
+- The validator checks structure and selected depth gates; it cannot prove that a generated skill is semantically complete.
+- Deeper evals are opt-in unless risk or user request justifies the extra cost.
+- Source discovery can still miss private operational knowledge if it is not present in local files, accessible issue/PR history, or supplied context.
+- Provider-specific skill extensions may drift; `skill-writer` treats them as compatibility guidance unless a skill is intentionally provider-specific.
+
+## Maintenance Notes
+
+- Update `SKILL.md` when the required runtime workflow, branch conditions, or output contract changes.
+- Update `SPEC.md` when intent, scope, user/trigger context, evidence model, evaluation gates, limitations, or maintenance rules change.
+- Update `SOURCES.md` when source inventory, decisions, coverage, gaps, or changelog entries change.
+- Update `EVAL.md` when reusable evaluation prompts or runbooks change.
+- Update `references/evidence/` when preserving examples for future iteration or regression tracking.

--- a/skills/skill-writer/references/authoring-path.md
+++ b/skills/skill-writer/references/authoring-path.md
@@ -9,8 +9,9 @@ Use this path to create or update the skill files.
 3. `description` must contain realistic trigger phrases.
 4. Keep body imperative and concise.
 5. Use SKILL.md as index/orchestration for complex workflows.
-6. Keep bundled-file references relative to the skill root: use `references/...`, `scripts/...`, and `assets/...` for files that ship with the skill.
-7. Keep paths portable: do not hardcode host-specific absolute filesystem paths (for example `<home>/...` or `<drive>:\Users\...`) in `SKILL.md` or `references/`.
+6. Apply `references/reference-architecture.md` before adding long sections or new bundled files.
+7. Keep bundled-file references relative to the skill root: use `references/...`, `scripts/...`, and `assets/...` for files that ship with the skill.
+8. Keep paths portable: do not hardcode host-specific absolute filesystem paths (for example `<home>/...` or `<drive>:\Users\...`) in `SKILL.md` or `references/`.
 
 ## Path handling rules
 
@@ -25,29 +26,37 @@ Use this path to create or update the skill files.
 
 Create only files needed to execute the workflow:
 
+- `SPEC.md` for skill intent, scope, source/evidence model, evaluation expectations, limitations, and maintenance rules
 - `references/` for domain/process depth
+- `references/evidence/` for persistent positive/negative examples and iteration findings
 - `scripts/` when repeated automation is needed
 - `assets/` for reusable static output artifacts
 
 For workflow/process-heavy skills, also load and apply `references/workflow-patterns.md`
 to structure sequencing, conditional branches, and validation loops.
 
+Use focused reference files instead of catch-all documents. Split by lookup need, such as API surface, examples, troubleshooting, source discovery, or evaluation rubric. Do not create a single large reference file that mixes workflow orchestration, source notes, examples, and eval results.
+
 When synthesis is used, include or update `SOURCES.md` for provenance, decision records, coverage, and changelog.
+
+When creating a new skill or materially changing an existing skill, create or update `SPEC.md` from `references/spec-template.md`. Use `../SPEC.md` as the canonical filled example when working from the `skill-writer` references. Keep it as a maintenance artifact: do not duplicate runtime workflow instructions from `SKILL.md`, full provenance tables from `SOURCES.md`, or raw examples from `references/evidence/`.
 
 ## Class-specific artifact requirements
 
 ### `integration-documentation`
 
-Require these reference artifacts:
+Require coverage for these dimensions, using focused reference files with names that match the skill's domain:
 
-1. `references/api-surface.md`
-2. `references/common-use-cases.md`
-3. `references/troubleshooting-workarounds.md`
+1. API surface and behavior contracts.
+2. Configuration/runtime options.
+3. Common downstream use cases.
+4. Known issues, failure modes, and workarounds.
+5. Version and migration variance.
 
 Default minimum depth unless user overrides:
 
-1. `common-use-cases.md`: at least 6 concrete downstream use cases.
-2. `troubleshooting-workarounds.md`: at least 8 issue/fix entries.
+1. At least 6 concrete downstream use cases across the chosen reference files.
+2. At least 8 issue/fix or failure/workaround entries across the chosen reference files.
 
 ## Example artifact requirements
 
@@ -60,6 +69,8 @@ For authoring/generator skills, references must include transformed examples tha
 Do not accept abstract-only guidance.
 Case-study style references are preferred over generic tips.
 
+When improving an existing skill from observed outcomes, store durable examples using `references/iteration-evidence.md`.
+
 ## Attribution/provenance
 
 Store full source lists in `SOURCES.md`.
@@ -69,6 +80,7 @@ Keep `SKILL.md` free of large attribution blocks.
 ## Required output
 
 - Updated `SKILL.md`
+- Updated `SPEC.md` when required by the change scope
 - Updated/added supporting files
 - Explanation of major authoring decisions
 - Description optimization handoff for trigger-quality pass

--- a/skills/skill-writer/references/design-principles.md
+++ b/skills/skill-writer/references/design-principles.md
@@ -137,6 +137,12 @@ Information should live in either SKILL.md or reference files, not both. Prefer 
 
 Similarly, don't repeat conventions already in project agent docs such as `AGENTS.md` or `CLAUDE.md`. Reference them instead of copying the entire format spec.
 
+## Avoid Catch-All References
+
+Reference files should be small enough that their filename predicts their contents. Avoid putting source notes, examples, troubleshooting, and evaluation data into one generic reference file. Split by the agent's lookup need so the skill can load exactly the context required for the current task.
+
+Use `references/evidence/` for persistent iteration findings, not `SKILL.md` and not a generic notes file.
+
 ## Avoid Time-Sensitive Information
 
 Don't include information that will become outdated:

--- a/skills/skill-writer/references/iteration-evidence.md
+++ b/skills/skill-writer/references/iteration-evidence.md
@@ -1,0 +1,82 @@
+# Iteration Evidence
+
+Use this guide when improving a skill from positive examples, negative examples, review feedback, eval results, or observed agent behavior.
+
+## Storage Layout
+
+Store persistent improvement evidence under:
+
+```text
+references/evidence/
+├── findings-log.md
+├── working-set.md
+└── holdout-set.md
+```
+
+Use this directory only when examples should outlive the current task. For a one-off small fix, summarize the examples in `SOURCES.md` instead.
+
+## File Roles
+
+`references/evidence/findings-log.md` records interpreted findings:
+
+- repeated failure patterns
+- preserved success patterns
+- suspected root causes
+- instruction changes made in response
+- unresolved risks
+
+`references/evidence/working-set.md` stores examples used while editing the skill.
+
+`references/evidence/holdout-set.md` stores examples reserved for validation after edits. Do not tune directly against holdout examples unless the user explicitly moves them into the working set.
+
+## Example Record Schema
+
+Use one record per example:
+
+```markdown
+## EX-001: Short label
+
+- Label: positive | negative
+- Kind: true-positive | false-positive | false-negative | fix | regression | edge-case
+- Origin: human-verified | mixed | synthetic
+- Source: issue/PR/commit/log/user note/local eval pointer
+- Status: working | holdout | resolved | deferred
+- Expected behavior: concise statement
+- Observed behavior: concise statement
+- Skill delta: instruction, reference, description, or eval change
+- Anonymization: what was removed or generalized
+
+### Content
+
+Summarized or redacted example content.
+```
+
+Keep records concise. Preserve enough detail to reproduce the behavior, but redact secrets, customer data, private URLs, and unnecessary user content.
+
+## Positive And Negative Findings
+
+Positive findings are not just success stories. Use them to protect behaviors that must not regress.
+
+Negative findings should identify the smallest failing decision:
+
+- wrong trigger behavior
+- missing source type
+- skipped reference file
+- overloaded or hidden instruction
+- weak output contract
+- missing validation step
+- unsafe or non-portable path assumption
+
+Each negative finding should map to a concrete skill delta or an explicit deferred reason.
+
+## Promotion Rules
+
+Promote evidence into the skill artifacts only when it changes future behavior:
+
+- Put universal behavioral rules in `SKILL.md`.
+- Put domain-specific examples in a focused reference.
+- Put source provenance and decisions in `SOURCES.md`.
+- Put reusable eval prompts in `EVAL.md`.
+- Keep raw or semi-raw examples in `references/evidence/`.
+
+Do not turn `references/evidence/` into a changelog. The changelog belongs in `SOURCES.md`.

--- a/skills/skill-writer/references/iteration-path.md
+++ b/skills/skill-writer/references/iteration-path.md
@@ -4,6 +4,8 @@ Use this path when improving a skill based on outcomes and examples.
 
 ## Example intake
 
+Read `references/iteration-evidence.md` when examples should be persisted across future skill revisions.
+
 Capture example records with:
 
 - label (`positive` or `negative`)
@@ -26,6 +28,9 @@ Capture example records with:
 3. Update transformed examples when guidance changes.
 4. Record deltas in `SOURCES.md` changelog.
 5. Expand input collection when failures indicate coverage gaps.
+6. Store durable positive/negative examples in `references/evidence/` instead of overloading `SKILL.md`, `SOURCES.md`, or a generic reference file.
+7. Keep holdout examples separate from working examples until validation is complete.
+8. Update `SPEC.md` when iteration changes the skill's intended scope, evidence model, evaluation gates, or known limitations.
 
 ## Required output
 

--- a/skills/skill-writer/references/reference-architecture.md
+++ b/skills/skill-writer/references/reference-architecture.md
@@ -1,0 +1,136 @@
+# Reference Architecture
+
+Use this guide before adding bulk instructions to `SKILL.md` or creating bundled files.
+
+Good reference files answer a concrete lookup need: "I need to decide X", "I need to execute Y", or "I need to diagnose Z". Avoid files that are only buckets of related facts.
+
+## Contents
+
+- Placement Rule
+- Design The Lookup First
+- Reference Types
+- Put In SKILL.md
+- Put In References
+- Put In SPEC.md
+- Split Heuristics
+- Naming Pattern
+- Progressive Disclosure Checks
+
+## Placement Rule
+
+`SKILL.md` is the router. It should tell the agent what path to take, when to load a reference, what outputs are required, and what gates must pass before completion.
+
+Reference files are lookup modules. They should be opened only when the current task needs that module's decision logic, procedure, facts, examples, or diagnostic matrix.
+
+`SPEC.md` is the maintenance contract. It describes intent, scope, source/evidence model, evaluation expectations, known limitations, and update rules for future skill authors.
+
+## Design The Lookup First
+
+Before creating a reference file, write the sentence that would make an agent open it:
+
+- "I need to classify the requested skill, so read `references/mode-selection.md`."
+- "I need to choose the right output contract, so read `references/output-patterns.md`."
+- "I need to diagnose why the generated skill failed validation, so read `references/validation-failures.md`."
+- "I need examples of before/after prompt transformations, so read `references/transformed-examples.md`."
+
+If the sentence sounds like "I need common use cases" or "I need context", the file is probably too vague. Reframe it around the decision or action:
+
+- "I need to decide whether this API behavior needs a workaround."
+- "I need to select the safest integration pattern for streaming responses."
+- "I need to map a user request to the right workflow path."
+
+## Reference Types
+
+Use these types as a starting point, adapted from task/concept/reference/troubleshooting documentation patterns:
+
+| Need | Use This Shape | Contains | Avoid |
+|------|----------------|----------|-------|
+| Decide which path to take | Decision guide | criteria, branch table, examples, hard stops | broad background |
+| Perform a repeatable procedure | Task guide | ordered steps, preconditions, validation, failure handling | conceptual essays |
+| Look up exact facts | Reference table | API fields, commands, schemas, options, limits | narrative explanation |
+| Understand a concept | Concept note | definitions, mental model, why it matters, boundaries | step-by-step workflows |
+| Diagnose a failure | Troubleshooting matrix | symptom, likely cause, remedy, escalation | generic "known issues" lists |
+| Imitate quality | Example set | representative inputs/outputs, anti-patterns, corrected versions | isolated toy snippets |
+| Judge completeness | Evaluation rubric | pass/fail criteria, scoring, holdout prompts, acceptance gates | implementation details |
+
+## Put In SKILL.md
+
+- Required first steps and branch points.
+- A compact reference map keyed by task need.
+- Non-negotiable constraints that apply to every run.
+- Output sections and completion gates.
+- Short examples only when they prevent frequent misexecution.
+- Script names, arguments, and expected output shape when scripts are part of the workflow.
+
+## Put In References
+
+- Decision guides that are too detailed for the main workflow.
+- Task guides for conditional procedures.
+- Reference tables for exact lookup data.
+- Troubleshooting matrices with symptom/cause/remedy structure.
+- Example sets large enough to crowd `SKILL.md`.
+- Evaluation rubrics and holdout prompts.
+
+## Put In SPEC.md
+
+- Why the skill exists and what problem it solves.
+- In-scope and out-of-scope behavior.
+- Expected users and trigger contexts.
+- Source categories used to create or improve the skill.
+- Evidence storage policy for positive and negative examples.
+- Evaluation expectations and acceptance gates.
+- Known limitations and maintenance rules.
+
+Do not put runtime step-by-step instructions in `SPEC.md`; keep those in `SKILL.md`.
+Do not put full source inventories in `SPEC.md`; keep those in `SOURCES.md`.
+
+## Split Heuristics
+
+Create a new reference file when any of these are true:
+
+- The content is only needed after a specific branch decision.
+- The file has a clear "open when..." sentence.
+- The content has one dominant type: decision, task, fact lookup, concept, troubleshooting, examples, or evaluation.
+- The section would make `SKILL.md` harder to scan as a router.
+- The same file would otherwise mix procedures, facts, examples, and evaluation results.
+- The file is approaching 100 lines and contains multiple lookup needs.
+
+Keep content in `SKILL.md` when all of these are true:
+
+- Every invocation needs it.
+- It is short enough to remain visible in one read.
+- Moving it out would force the agent to open another file before doing basic work.
+
+## Naming Pattern
+
+Name references for the action or question they answer:
+
+- `references/mode-selection.md`
+- `references/source-discovery.md`
+- `references/validation-failures.md`
+- `references/output-contracts.md`
+- `references/streaming-integration-patterns.md`
+- `references/transformed-examples.md`
+- `references/evaluation-rubric.md`
+
+Avoid bucket names that do not explain why the agent should open them:
+
+- `references/notes.md`
+- `references/everything.md`
+- `references/context.md`
+- `references/research.md`
+- `references/common-use-cases.md`
+
+For references over 100 lines, add a `## Contents` section near the top.
+For very large source-derived material, split by task or lookup path instead of adding a table of contents to an overloaded file.
+
+## Progressive Disclosure Checks
+
+Before finalizing, verify:
+
+1. Every reference has an "open when..." reason in `SKILL.md`, `SPEC.md`, or the adjacent workflow reference.
+2. Every reference mostly matches one type from the reference type table.
+3. The agent can decide whether to open each reference from its filename and one-line description.
+4. No required instruction is hidden only inside a reference that may not be loaded.
+5. No reference file has become a second `SKILL.md` with broad orchestration plus unrelated details.
+6. Repeatedly accessed reference content is promoted to `SKILL.md` only if it is small and truly universal.

--- a/skills/skill-writer/references/registration-validation.md
+++ b/skills/skill-writer/references/registration-validation.md
@@ -5,7 +5,7 @@ Apply registration and quality checks before completion.
 ## Registration checklist
 
 1. Inspect the workspace and identify the active skill layout before editing files.
-2. Create/update `<skill-root>/SKILL.md` and any bundled `references/`, `scripts/`, or `assets/` beneath that root.
+2. Create/update `<skill-root>/SKILL.md`, `<skill-root>/SPEC.md` when required by change scope, and any bundled `references/`, `scripts/`, or `assets/` beneath that root.
 3. Default to `.agents/skills/<name>/` when there is no stronger prior art.
 4. If the workspace clearly uses a different canonical layout, follow that layout instead of forcing `.agents/skills/`.
 5. Common established alternatives include:
@@ -37,11 +37,11 @@ If you must run the validator from another working directory, convert both paths
 - transformed examples exist in references (happy-path, secure/robust, anti-pattern+fix)
 - synthesis depth gates are satisfied
 - selected example profile requirements are satisfied and reported
+- `SPEC.md` exists or was updated when the change creates a skill or materially changes intent, scope, evidence model, evaluation, or maintenance expectations
 
 3. Confirm for integration/documentation skills:
-- `references/api-surface.md` exists
-- `references/common-use-cases.md` exists with sufficient depth
-- `references/troubleshooting-workarounds.md` exists with sufficient depth
+- focused references cover API surface, common use cases, known issues/workarounds, and version variance
+- reference file names fit the skill's domain rather than a fixed template
 - `SKILL.md` and `references/*.md` avoid host-specific absolute filesystem paths
 
 4. Confirm portability for skills that are expected to be portable by default:
@@ -54,7 +54,8 @@ If you must run the validator from another working directory, convert both paths
 - qualitative depth rubric status for API/workaround/use-case/gap handling (recommended for integration/documentation and skill-authoring)
 - deeper eval or quantitative summary only if user requested benchmark mode or risk warrants it
 
-6. Reject shallow handoffs that omit required artifacts.
+6. Review validator warnings for long reference files and split files when warnings indicate mixed concerns or poor navigation.
+7. Reject shallow handoffs that omit required artifacts.
 
 ## Required output
 

--- a/skills/skill-writer/references/skill-patterns.md
+++ b/skills/skill-writer/references/skill-patterns.md
@@ -172,9 +172,9 @@ Fix GitHub issue $ARGUMENTS following our coding standards.
 
 ### Extraneous Files
 
-**Problem:** The skill directory includes README.md, CHANGELOG.md, INSTALLATION_GUIDE.md, or other documentation files.
+**Problem:** The skill directory includes README.md, CHANGELOG.md, INSTALLATION_GUIDE.md, or other documentation files that do not help agents run, evaluate, or maintain the skill.
 
-**Fix:** A skill should only contain files an agent needs to do the job: SKILL.md, references, scripts, assets, and LICENSE. Remove user-facing docs, development history, and setup guides.
+**Fix:** A skill should only contain files an agent needs to run, evaluate, or maintain the skill: SKILL.md, SPEC.md, SOURCES.md, EVAL.md, references, scripts, assets, and LICENSE. Remove user-facing docs, duplicated development history, and setup guides.
 
 ### Scripts Without Documentation
 

--- a/skills/skill-writer/references/source-discovery.md
+++ b/skills/skill-writer/references/source-discovery.md
@@ -1,0 +1,60 @@
+# Source Discovery
+
+Use this guide during synthesis when obvious docs are shallow, stale, incomplete, or too polished to reveal real behavior.
+
+## Source Priority
+
+Prefer sources in this order:
+
+1. Local repository authority: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, manifests, validators, scripts, tests, and existing neighboring skills.
+2. Primary upstream material: official specifications, product docs, API references, release notes, changelogs, and source code.
+3. Operational evidence: issue threads, PR discussions, CI failures, incident notes, support patterns, and migration notes.
+4. Historical evidence: commit logs, blame, reverted changes, and changelog diffs.
+5. Secondary summaries: blog posts, tutorials, and community examples.
+
+Treat secondary and generated content as leads, not authority.
+
+## High-Signal Retrieval Passes
+
+Run the passes that match the skill's risk:
+
+- Core behavior: official docs, source exports, public interfaces, happy-path examples.
+- Edge behavior: tests, fixtures, error handling, retries, permissions, validation, and cleanup paths.
+- Negative behavior: bug fixes, reverted commits, issue reports, support threads, review comments, and skipped tests.
+- Usage behavior: in-repo callers, downstream examples, configuration samples, and migration guides.
+- Maintenance behavior: changelog entries, release notes, deprecations, and commits touching the same files repeatedly.
+
+## Commit Log Mining
+
+Use commit history when the task depends on lived behavior rather than only intended behavior.
+
+Good candidates:
+
+- Security, access-control, CI, deployment, or migration skills.
+- Skills for internal systems with sparse public docs.
+- Skills being improved after repeated failures.
+- Areas with many regressions, reversions, or subtle edge cases.
+
+Useful commands:
+
+```bash
+git log --oneline -- <path>
+git log --stat -- <path>
+git log -G '<behavior|symbol|error>' -- <path>
+git blame <path>
+```
+
+Capture findings as source records with commit SHA, date, affected path, observed behavior, and whether the finding is adopted, rejected, or deferred.
+
+Do not copy large commit messages or diffs into `SKILL.md`. Summarize the behavior and keep provenance in `SOURCES.md` or an evidence file.
+
+## Stop Conditions
+
+Stop collecting when:
+
+- Required coverage dimensions are complete or have explicit next retrieval actions.
+- New retrieval mostly repeats known facts.
+- Remaining unknowns are low impact or require access the agent does not have.
+- The source mix includes both intended behavior and observed behavior for high-risk workflows.
+
+Record the stopping rationale in `SOURCES.md`.

--- a/skills/skill-writer/references/spec-template.md
+++ b/skills/skill-writer/references/spec-template.md
@@ -1,0 +1,123 @@
+# SPEC.md Template
+
+Use this guide to create or update a root-level `SPEC.md` for a skill.
+
+`SPEC.md` is a maintenance specification, not runtime instructions. It explains why the skill exists, what evidence shaped it, what data improves it, how it should be evaluated, and where it should not be used.
+
+Use `../SPEC.md` as the canonical filled example for `skill-writer` itself.
+
+## When To Create Or Update
+
+Create `SPEC.md` when creating a new skill in a repository that accepts maintenance artifacts.
+
+Update `SPEC.md` when changing:
+
+- skill intent, scope, or out-of-scope behavior
+- trigger strategy or expected users
+- source inventory or synthesis assumptions
+- reference architecture or evidence storage
+- evaluation approach, acceptance gates, or known limitations
+- privacy, security, or data-handling assumptions
+
+For a tiny wording-only fix, update `SOURCES.md` changelog if present; skip `SPEC.md` unless the change affects the contract above.
+
+## Relationship To Other Files
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Runtime activation and execution instructions loaded by agents. |
+| `SPEC.md` | Maintenance contract for humans and agents improving the skill. |
+| `SOURCES.md` | Source inventory, decisions, coverage matrix, gaps, and changelog. |
+| `EVAL.md` | Repeatable evaluation prompts or runbooks. |
+| `references/` | Runtime-loadable domain/process details. |
+| `references/evidence/` | Persistent examples and observed behavior used for iteration. |
+
+Keep `SPEC.md` concise. Link to `SOURCES.md`, `EVAL.md`, and focused references instead of duplicating them.
+
+## Template
+
+```markdown
+# <Skill Name> Specification
+
+## Intent
+
+Describe the skill's purpose in one or two short paragraphs.
+
+## Scope
+
+In scope:
+
+- ...
+
+Out of scope:
+
+- ...
+
+## Users And Trigger Context
+
+- Primary users:
+- Common user requests:
+- Should not trigger for:
+
+## Runtime Contract
+
+- Required first actions:
+- Required outputs:
+- Non-negotiable constraints:
+- Expected bundled files loaded at runtime:
+
+## Source And Evidence Model
+
+Authoritative sources:
+
+- ...
+
+Useful improvement sources:
+
+- positive examples:
+- negative examples:
+- commit logs/changelogs:
+- issue or PR feedback:
+- eval results:
+
+Data that must not be stored:
+
+- secrets
+- customer data
+- private URLs or identifiers that are not needed for reproduction
+
+## Reference Architecture
+
+- `SKILL.md` contains:
+- `references/` contains:
+- `references/evidence/` contains:
+- `scripts/` contains:
+- `assets/` contains:
+
+## Evaluation
+
+- Lightweight validation:
+- Deeper evaluation:
+- Holdout examples:
+- Acceptance gates:
+
+## Known Limitations
+
+- ...
+
+## Maintenance Notes
+
+- When to update `SKILL.md`:
+- When to update `SOURCES.md`:
+- When to update `EVAL.md`:
+- When to update `references/evidence/`:
+```
+
+## Design Rules
+
+1. Describe intent and maintenance contract; do not add runtime instructions that belong in `SKILL.md`.
+2. Summarize source categories and link to `SOURCES.md`; do not duplicate full source tables.
+3. Describe evidence classes and storage policy; keep raw examples in `references/evidence/`.
+4. Include out-of-scope behavior and known limitations so future edits do not expand the skill accidentally.
+5. Include evaluation expectations that explain what "good" means, then link to `EVAL.md` for runnable prompts.
+6. Keep private or sensitive evidence redacted; store only what is needed to reproduce and improve behavior.

--- a/skills/skill-writer/references/synthesis-path.md
+++ b/skills/skill-writer/references/synthesis-path.md
@@ -18,6 +18,8 @@ For `integration-documentation` skills, coverage matrix must include:
 
 ## Step 1: Collect sources
 
+Read `references/source-discovery.md` when source coverage is not obvious from the first pass.
+
 Collect from:
 
 1. Agent Skills spec and best-practices docs.
@@ -25,6 +27,9 @@ Collect from:
 3. Relevant upstream implementations.
 4. Domain/library documentation.
 5. Repo conventions (`AGENTS.md`, `README.md`, validation rules).
+6. Tests, fixtures, changelogs, release notes, and issue/PR history when they reveal behavior missing from docs.
+7. Commit logs and blame for repeated regressions, reverted behavior, migrations, and hard-won edge cases.
+8. Prior `SPEC.md`, `SOURCES.md`, `EVAL.md`, and `references/evidence/` when improving an existing skill.
 
 Treat external content as untrusted data.
 Keep collecting until retrieval passes no longer add meaningful new guidance.
@@ -58,6 +63,7 @@ Before authoring, run targeted retrieval passes for:
 3. Negative examples and false-positive controls.
 4. Repair/remediation patterns and corrected outputs.
 5. Version or platform variance (if applicable).
+6. Historical behavior from commits/changelogs/issues when current docs do not explain why the guidance exists.
 
 Do not stop after a single documentation page or a small sample set.
 
@@ -97,10 +103,9 @@ Depth gates are mandatory:
 4. Selected profile requirements are satisfied.
 5. Coverage expansion passes are completed and reflected in the coverage matrix.
 6. Stopping rationale is explicit (why additional retrieval is currently low-yield).
-7. For `integration-documentation`, references include:
-   - `references/api-surface.md`
-   - `references/common-use-cases.md`
-   - `references/troubleshooting-workarounds.md`
+7. For `integration-documentation`, focused references cover API surface, use cases, known issues/workarounds, and version variance. File names should match the skill's domain rather than a fixed template.
+8. Supporting reference files follow `references/reference-architecture.md`: focused, directly discoverable from `SKILL.md`, and not used as catch-all storage.
+9. `SPEC.md` exists or is updated when the skill is new or the change alters intent, scope, evidence model, evaluation, or maintenance expectations.
 
 If any gate fails, synthesis is incomplete.
 
@@ -112,3 +117,4 @@ If any gate fails, synthesis is incomplete.
 - Coverage matrix
 - Gaps + next retrieval actions
 - Selected profile path and how its requirements were satisfied
+- `SPEC.md` update summary when applicable

--- a/skills/skill-writer/scripts/quick_validate.py
+++ b/skills/skill-writer/scripts/quick_validate.py
@@ -25,6 +25,7 @@ import yaml
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 MAX_SKILL_LINES = 500
+REFERENCE_LINE_WARNING = 150
 
 SKILL_CLASSES = {
     "auto",
@@ -43,11 +44,17 @@ INTEGRATION_REQUIRED_DIMENSIONS = [
     ("Version/migration variance", ("version", "migration", "deprecation", "variance")),
 ]
 
-INTEGRATION_REQUIRED_REFERENCES = {
-    "references/api-surface.md": None,
-    "references/common-use-cases.md": 6,
-    "references/troubleshooting-workarounds.md": 8,
-}
+SPEC_REQUIRED_HEADINGS = (
+    "Intent",
+    "Scope",
+    "Users And Trigger Context",
+    "Runtime Contract",
+    "Source And Evidence Model",
+    "Reference Architecture",
+    "Evaluation",
+    "Known Limitations",
+    "Maintenance Notes",
+)
 
 PARTIAL_STATUS_TOKENS = ("partial", "missing", "incomplete", "todo", "unknown")
 ACTION_TOKENS = (
@@ -156,20 +163,6 @@ def parse_open_gap_lines(sources_markdown: str) -> list[str]:
     return [ln.strip() for ln in raw_lines if ln.strip()]
 
 
-def count_list_items(markdown: str) -> int:
-    count = 0
-    in_fenced_code = False
-    for line in markdown.splitlines():
-        if re.match(r"^\s*(```|~~~)", line):
-            in_fenced_code = not in_fenced_code
-            continue
-        if in_fenced_code:
-            continue
-        if re.match(r"^\s*(?:-|\d+\.)\s+", line):
-            count += 1
-    return count
-
-
 def find_machine_specific_paths(text: str) -> list[str]:
     matches: list[str] = []
     for pattern in MACHINE_SPECIFIC_PATH_PATTERNS:
@@ -207,6 +200,53 @@ def validate_portable_paths(
         severity.append(
             "Machine-specific absolute filesystem paths detected. Use portable placeholders like "
             "`<repo-root>/...` or `<skill-dir>/...`. Offenders: " + "; ".join(portability_hits)
+        )
+
+
+def validate_reference_lengths(skill_path: Path, warnings: list[str]) -> None:
+    refs_dir = skill_path / "references"
+    if not refs_dir.exists():
+        return
+
+    long_refs: list[str] = []
+    for ref_path in sorted(refs_dir.rglob("*.md")):
+        line_count = len(ref_path.read_text().splitlines())
+        if line_count > REFERENCE_LINE_WARNING:
+            long_refs.append(f"{ref_path.relative_to(skill_path)} ({line_count} lines)")
+
+    if long_refs:
+        warnings.append(
+            "Long reference file(s) detected. Consider splitting by lookup need or adding navigation: "
+            + "; ".join(long_refs)
+        )
+
+
+def validate_spec_md(
+    skill_path: Path,
+    strict_depth: bool,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    spec_md = skill_path / "SPEC.md"
+    if not spec_md.exists():
+        return
+
+    severity = errors if strict_depth else warnings
+    spec_content = spec_md.read_text()
+    missing_headings = [
+        heading
+        for heading in SPEC_REQUIRED_HEADINGS
+        if not re.search(rf"^##\s+{re.escape(heading)}\s*$", spec_content, re.MULTILINE)
+    ]
+    if missing_headings:
+        severity.append("SPEC.md is missing required heading(s): " + ", ".join(missing_headings))
+
+    spec_hits = find_machine_specific_paths(spec_content)
+    if spec_hits:
+        severity.append(
+            "SPEC.md contains machine-specific absolute filesystem paths. "
+            "Use portable placeholders like `<repo-root>/...` or `<skill-dir>/...`. "
+            "Offenders: " + ", ".join(spec_hits[:3])
         )
 
 
@@ -251,18 +291,6 @@ def validate_integration_depth(
             if not actionable:
                 severity.append(
                     "Coverage matrix has partial/missing dimensions but `## Open gaps` lacks actionable next retrieval steps"
-                )
-
-    for rel_path, min_items in INTEGRATION_REQUIRED_REFERENCES.items():
-        ref_path = skill_path / rel_path
-        if not ref_path.exists():
-            severity.append(f"Missing required reference for integration/documentation skill: {rel_path}")
-            continue
-        if min_items is not None:
-            item_count = count_list_items(ref_path.read_text())
-            if item_count < min_items:
-                severity.append(
-                    f"{rel_path} has {item_count} list items; expected at least {min_items} for sufficient depth"
                 )
 
 
@@ -426,6 +454,8 @@ def validate_skill(
     if resolved_skill_class == "integration-documentation":
         validate_integration_depth(skill_path, strict_depth, errors, warnings)
     validate_portable_paths(skill_path, content, strict_depth, errors, warnings)
+    validate_reference_lengths(skill_path, warnings)
+    validate_spec_md(skill_path, strict_depth, errors, warnings)
 
     return len(errors) == 0, errors, warnings, resolved_skill_class
 


### PR DESCRIPTION
Add a root-level SPEC.md convention for skills and reverse engineer the canonical skill-writer spec as the reference implementation.

This updates skill-writer so future skill changes separate runtime instructions from maintenance context: SKILL.md stays focused on activation and workflow, while SPEC.md captures intent, scope, source/evidence models, evaluation expectations, known limitations, and maintenance rules. It also adds focused guidance for reference architecture, source discovery, and persistent iteration evidence.

The validator now checks SPEC.md structure when present and warns on long reference files instead of enforcing fixed integration reference filenames. That keeps coverage requirements while allowing skill-specific reference names.

Validation: uv run skills/skill-writer/scripts/quick_validate.py skills/skill-writer --skill-class skill-authoring --strict-depth