### PR TITLE
docs(pr-writer): Tighten PR body guidance

### DIFF
--- a/skills/pr-writer/SKILL.md
+++ b/skills/pr-writer/SKILL.md
@@ -57,17 +57,55 @@ Understand the scope and purpose of all changes before writing the description.
 
 ### Step 3: Write the PR Description
 
-Use this structure for PR descriptions (ignoring any repository PR templates):
+Use this structure for PR descriptions, ignoring any repository PR templates:
 
 ```markdown
-<brief description of what the PR does>
-
-<why these changes are being made - the motivation>
-
-<alternative approaches considered, if any>
-
-<any additional context reviewers need>
+<1-3 sentence summary of the change and why it matters. Keep this short.>
 ```
+
+When there is a known issue, ticket, or related PR, add references at the end. Do not invent one.
+
+When the PR has distinct changes reviewers should scan, add 0-3 bold emphasis blocks after the opening summary:
+
+```markdown
+**<Important Change>**
+
+<1-2 sentences explaining the important implementation, behavior, or review-relevant change.>
+```
+
+When direct comparison is the clearest explanation, add a before/after block under the relevant paragraph or emphasis block:
+
+````markdown
+Before, <old shape or behavior in one sentence>:
+
+```<format-or-pseudocode>
+...
+```
+
+After, <new shape or behavior in one sentence>:
+
+```<format-or-pseudocode>
+...
+```
+````
+
+Treat the bold sections as optional emphasis blocks, not mandatory headings. Use them when the PR has one or more distinct changes that reviewers should scan quickly. Omit them for simple PRs where the opening summary is enough.
+
+Use before/after examples only when that is the clearest way to explain the changeset. They are usually useful for changed contracts or output shapes, such as JSON responses, schemas, config, CLI output, event payloads, permissions, or input formats. Omit them when prose is clearer.
+
+Prefer:
+- A concise opening summary, usually 1-3 sentences
+- 0-3 bold emphasis blocks for the parts that matter most
+- Before/after examples only for changes that benefit from direct comparison, with separate fenced blocks for the old and new forms
+- Known issue references at the end, when available
+
+Avoid:
+- Essays, exhaustive file-by-file walkthroughs, or copied commit logs
+- Generic headings like "Summary" or "Changes"
+- A bold block for every touched file
+- Inline before/after snippets that are hard to compare
+- Placeholder issue references when no issue is known
+- Repeating details that are obvious from the diff
 
 **Do NOT include:**
 - "Test plan" sections
@@ -76,10 +114,10 @@ Use this structure for PR descriptions (ignoring any repository PR templates):
 - Customer data — customer/org names, user emails, support ticket contents, or PII. Describe the technical symptom, not who hit it, and if available, reference the internal ticket (e.g. `Fixes SENTRY-1234`). PRs are typically public on open-source repos.
 
 **Do include:**
-- Clear explanation of what and why
-- Links to relevant issues or tickets
+- Clear explanation of what changed and why it matters
+- Links to relevant issues or tickets, when known
 - Context that isn't obvious from the code
-- Notes on specific areas that need careful review
+- Specific review notes when a part of the diff needs extra attention
 
 ### Step 4: Create the PR
 
@@ -97,6 +135,15 @@ EOF
 
 ## PR Description Examples
 
+### Simple PR
+
+```markdown
+Collapse the AI Customizations section by default in the sessions sidebar.
+
+The section now starts hidden so it does not consume space before users need
+it. Users who expand it keep the same persisted preference behavior as before.
+```
+
 ### Feature PR
 
 ```markdown
@@ -106,38 +153,73 @@ When an alert is updated or resolved, we now post a reply to the original
 Slack thread instead of creating a new message. This keeps related
 notifications grouped and reduces channel noise.
 
-Previously considered posting edits to the original message, but threading
-better preserves the timeline of events and works when the original message
-is older than Slack's edit window.
+**Notification Threading**
+
+Resolved and updated alerts now reply to the original Slack message instead
+of creating a new channel message.
 
 Refs SENTRY-1234
 ```
 
-### Bug Fix PR
+### Schema Change PR
 
-```markdown
-Handle null response in user API endpoint
+````markdown
+Switch run logs to chunk-level JSONL records
 
-The user endpoint could return null for soft-deleted accounts, causing
-dashboard crashes when accessing user properties. This adds a null check
-and returns a proper 404 response.
+Run logs now write one versioned record per analyzed chunk instead of one
+large skill-level record. This lets `warden runs follow` show findings as
+chunks complete while preserving durable run reconstruction at finalization.
 
-Found while investigating SENTRY-5678.
+**JSONL Shape**
 
-Fixes SENTRY-5678
+Before, each line represented a full skill result:
+
+```jsonc
+{
+  "run": {...},
+  "skill": "security-review",
+  "summary": "Found 2 issues",
+  "findings": [...],
+  "files": [...]
+}
 ```
+
+After, each line represents one chunk result:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "run": {...},
+  "skill": "security-review",
+  "chunk": {
+    "file": "src/api/auth.ts",
+    "index": 1,
+    "total": 2,
+    "lineRange": "42-45"
+  },
+  "status": "ok",
+  "findings": [...]
+}
+```
+
+Refs WARDEN-123
+````
 
 ### Refactor PR
 
-```markdown
+````markdown
 Extract validation logic to shared module
 
 Moves duplicate validation code from the alerts, issues, and projects
 endpoints into a shared validator class. No behavior change.
 
-This prepares for adding new validation rules in SENTRY-9999 without
-duplicating logic across endpoints.
-```
+**Shared Validator**
+
+The shared class keeps the existing endpoint behavior but gives future
+validation rules one place to live.
+
+Refs SENTRY-9999
+````
 
 ## Issue References
 

--- a/skills/pr-writer/SPEC.md
+++ b/skills/pr-writer/SPEC.md
@@ -1,0 +1,89 @@
+# PR Writer Specification
+
+## Intent
+
+The `pr-writer` skill creates and updates pull requests with concise, review-oriented titles and descriptions that match Sentry conventions.
+
+Its main job is to turn branch changes into a readable PR body that explains what changed, why it changed, and the few details reviewers need before reading the diff. It should avoid long essays and mechanical diff summaries.
+
+## Scope
+
+In scope:
+
+- Creating draft pull requests from committed feature branches.
+- Updating existing PR titles or descriptions.
+- Producing compact PR bodies with optional bold emphasis sections.
+- Including issue references and review context when useful.
+
+Out of scope:
+
+- Writing commits or deciding commit history policy.
+- Running full CI or iterating on failing checks.
+- Producing release notes, changelogs, or customer-facing announcements.
+- Including test-plan checklists in PR bodies.
+
+## Users And Trigger Context
+
+- Primary users: engineers and coding agents preparing Sentry pull requests.
+- Common user requests: create a PR, open a PR, update a PR body, edit a PR title, prepare changes for review.
+- Should not trigger for: code review requests, commit-only requests, CI-fix loops, or generic documentation writing.
+
+## Runtime Contract
+
+- Required first actions: verify the current branch, committed state, base branch, and diff scope before writing or updating a PR.
+- Required outputs: a conventional PR title and a concise PR body suitable for `gh pr create` or GitHub API update commands.
+- Non-negotiable constraints: never include customer data or PII, ignore repository PR templates, omit test-plan sections, and prefer draft PRs for newly opened pull requests.
+- Expected bundled files loaded at runtime: only `SKILL.md`.
+
+## Source And Evidence Model
+
+Authoritative sources:
+
+- Sentry engineering practices for code review.
+- Sentry commit message conventions.
+- Repository-level agent instructions.
+- Observed user preference for short PR bodies with optional bold emphasis sections.
+- `getsentry/warden#265` as a formatting exemplar for before/after examples on schema and output-shape changes.
+
+Useful improvement sources:
+
+- positive examples: PR descriptions that reviewers can scan quickly.
+- negative examples: PR bodies that read like essays, repeat the diff, or overuse headings.
+- commit logs/changelogs: only as source context, not as body text to paste.
+- issue or PR feedback: reviewer comments about missing context or excessive detail.
+- eval results: prompt-based checks for concise summaries, optional sections, and privacy boundaries.
+
+Data that must not be stored:
+
+- secrets
+- customer data
+- private customer, organization, or user identifiers
+- support ticket contents not needed for a public PR
+
+## Reference Architecture
+
+- `SKILL.md` contains runtime workflow, command patterns, PR body template, examples, and safety constraints.
+- `references/` contains no files currently; add focused style or evidence examples only if the runtime file becomes too long or repeated regressions show the examples need more room.
+- `references/evidence/` contains no files currently; use it for durable positive and negative PR body examples if iteration data accumulates.
+- `scripts/` contains no files currently.
+- `assets/` contains no files currently.
+
+## Evaluation
+
+- Lightweight validation: compare generated PR bodies against representative feature, schema-change, and refactor prompts for brevity, clarity, optional-section use, issue references, and privacy handling.
+- Deeper evaluation: maintain a small prompt set with expected body shapes if regressions recur.
+- Holdout examples: include at least one simple PR that should have no bold section, one PR with no known issue reference, and one API or input-format change that should use separate before/after fenced blocks.
+- Acceptance gates: output begins with a 1-3 sentence summary, uses no required generic headings, includes at most a few bold emphasis blocks, uses before/after examples only when direct comparison is the clearest explanation, omits unknown issue references instead of inventing placeholders, avoids test-plan sections, and does not include customer data.
+
+## Known Limitations
+
+- The skill cannot guarantee that issue references are correct unless the branch, commits, or user provide them, and should omit references rather than invent placeholders.
+- It relies on the agent's judgment to decide whether a bold emphasis block is useful.
+- Very large PRs may still need more context than the default body shape encourages.
+
+## Maintenance Notes
+
+- Update `SKILL.md` when PR creation workflow, title rules, body template, examples, or safety constraints change.
+- Update `SPEC.md` when intent, scope, evaluation gates, or evidence policy changes.
+- Add focused reference files only when examples or guidance would make `SKILL.md` noisy.
+- Keep public inventories pointed at the canonical `skills/pr-writer` skill, not mirrors.


### PR DESCRIPTION
Update pr-writer to prefer concise PR descriptions with optional emphasis blocks instead of default section-heavy bodies.

**PR Body Shape**

The default template is now a short summary, with optional bold emphasis blocks only when reviewers need scannable detail. Before/after examples are split into a separate pattern and reserved for changes where direct comparison is the clearest explanation, such as schemas, JSON, config, CLI output, or event payloads.

**Maintenance Contract**

Add a SPEC file for pr-writer that captures the intended scope, source evidence, evaluation gates, and known failure modes so future edits preserve the concise style.