### PR TITLE
feat(code-simplifier): Add behavior spec and evals

### DIFF
--- a/skills/code-simplifier/SKILL.md
+++ b/skills/code-simplifier/SKILL.md
@@ -1,119 +1,188 @@
 ---
 name: code-simplifier
-description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Use when asked to "simplify code", "clean up code", "refactor for clarity", "improve readability", or review recently modified code for elegance. Focuses on project-specific best practices.
+description: >
+  Simplify and refine code for clarity, consistency, and
+  maintainability while preserving exact functionality. Use when
+  asked to "simplify code", "clean up code", "refactor for
+  clarity", "improve readability", or when "reviewing recently
+  modified code for elegance".
 ---
 
 <!--
-Based on Anthropic's code-simplifier agent:
-https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-simplifier/agents/code-simplifier.md
+  Generated from spec.yaml. The behavior set, must-nots, and
+  triggers live in spec.yaml — edit there. `skillet improve` may
+  tune the prose in this file between runs to satisfy evals;
+  those tweaks survive until the spec itself changes.
+
+  Based on Anthropic's code-simplifier agent:
+  https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-simplifier/agents/code-simplifier.md
 -->
 
-# Code Simplifier
+## Preserve functionality exactly
 
-You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions.
+Change how the code does its work, never what it does. Every
+original feature, output, side effect, and edge case must remain
+intact after refinement — refinement is a behavior-preserving
+transformation, not a redesign. If a simplification would alter
+observable behavior, stop and surface the question instead of
+making the change.
 
-## Refinement Principles
+## Follow project coding standards
 
-### 1. Preserve Functionality
+Apply the standards from `CLAUDE.md` as you refine. This includes
+ES modules with proper import sorting and explicit extensions, the
+`function` keyword over arrow functions for top-level definitions,
+explicit return type annotations on top-level functions, React
+components with explicit `Props` types, error handling that avoids
+unnecessary `try/catch`, and consistent naming conventions.
+Refinement is the moment to bring drifted code back in line with
+these conventions.
 
-Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+## Reduce unnecessary complexity
 
-### 2. Apply Project Standards
+Cut nesting, redundant code, and abstractions that don't pay for
+themselves. Rename variables and functions so their purpose is
+obvious from the call site. Consolidate related logic that's been
+scattered, and remove comments that just restate what the code
+already says. The goal is fewer moving parts and clearer intent,
+not a smaller diff.
 
-Follow the established coding standards from CLAUDE.md including:
+## Avoid nested ternaries
 
-- Use ES modules with proper import sorting and extensions
-- Prefer `function` keyword over arrow functions
-- Use explicit return type annotations for top-level functions
-- Follow proper React component patterns with explicit Props types
-- Use proper error handling patterns (avoid try/catch when possible)
-- Maintain consistent naming conventions
+For multiple conditions, prefer `switch` statements or `if/else`
+chains over nested ternary operators. Nested ternaries pack
+control flow into expression syntax that's hard to scan and harder
+to extend — explicit conditional structures make each branch
+visible and easy to modify. A single ternary for a binary choice
+is fine; the moment a second `?` appears inside the first, switch
+to a statement form.
 
-### 3. Enhance Clarity
+## Choose clarity over brevity
 
-Simplify code structure by:
-
-- Reducing unnecessary complexity and nesting
-- Eliminating redundant code and abstractions
-- Improving readability through clear variable and function names
-- Consolidating related logic
-- Removing unnecessary comments that describe obvious code
-- **Avoiding nested ternary operators** - prefer switch statements or if/else chains for multiple conditions
-- Choosing clarity over brevity - explicit code is often better than overly compact code
-
-### 4. Maintain Balance
-
-Avoid over-simplification that could:
-
-- Reduce code clarity or maintainability
-- Create overly clever solutions that are hard to understand
-- Combine too many concerns into single functions or components
-- Remove helpful abstractions that improve code organization
-- Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
-- Make the code harder to debug or extend
-
-### 5. Focus Scope
-
-Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
-
-## Refinement Process
-
-1. **Identify** the recently modified code sections
-2. **Analyze** for opportunities to improve elegance and consistency
-3. **Apply** project-specific best practices and coding standards
-4. **Ensure** all functionality remains unchanged
-5. **Verify** the refined code is simpler and more maintainable
-6. **Document** only significant changes that affect understanding
+Explicit code beats compact code. Don't optimize for fewer lines:
+a five-line version that names its steps is better than a
+one-liner that requires the reader to mentally unpack it. Dense
+expressions and clever tricks are harder to debug, harder to
+extend, and harder for the next reader (often you) to trust. When
+the choice is between "shorter" and "obvious", pick obvious.
 
 ## Examples
 
-### Before: Nested Ternaries
-
-```typescript
-const status = isLoading ? 'loading' : hasError ? 'error' : isComplete ? 'complete' : 'idle';
-```
-
-### After: Clear Switch Statement
+Prefer explicit branches over nested ternaries:
 
 ```typescript
 function getStatus(isLoading: boolean, hasError: boolean, isComplete: boolean): string {
-  if (isLoading) return 'loading';
-  if (hasError) return 'error';
-  if (isComplete) return 'complete';
-  return 'idle';
+  if (isLoading) {
+    return "loading";
+  }
+  if (hasError) {
+    return "error";
+  }
+  if (isComplete) {
+    return "complete";
+  }
+  return "idle";
 }
 ```
 
-### Before: Overly Compact
+Break dense chains into named steps:
 
 ```typescript
-const result = arr.filter(x => x > 0).map(x => x * 2).reduce((a, b) => a + b, 0);
+const positiveNumbers = numbers.filter((number) => number > 0);
+const doubledNumbers = positiveNumbers.map((number) => number * 2);
+const total = doubledNumbers.reduce((sum, number) => sum + number, 0);
 ```
 
-### After: Clear Steps
-
-```typescript
-const positiveNumbers = arr.filter(x => x > 0);
-const doubled = positiveNumbers.map(x => x * 2);
-const sum = doubled.reduce((a, b) => a + b, 0);
-```
-
-### Before: Redundant Abstraction
-
-```typescript
-function isNotEmpty(arr: unknown[]): boolean {
-  return arr.length > 0;
-}
-
-if (isNotEmpty(items)) {
-  // ...
-}
-```
-
-### After: Direct Check
+Remove wrappers only when they add no domain meaning:
 
 ```typescript
 if (items.length > 0) {
-  // ...
+  renderItems(items);
 }
 ```
+
+Keep short helpers when they name a domain rule:
+
+```typescript
+function validateEmail(email: string): boolean {
+  return /^[^@]+@[^@]+\.[^@]+$/.test(email);
+}
+
+if (!validateEmail(data.email)) {
+  return {ok: false, error: "email"};
+}
+```
+
+## Maintain helpful abstractions
+
+Don't collapse abstractions that earn their keep. A function or
+component exists to name a concept and isolate a concern; merging
+several concerns back into one body for the sake of "simpler"
+usually trades clarity for line count. Over-simplification can
+itself be a form of clever code. Keep abstractions that
+meaningfully organize the code, even when inlining them would be
+mechanically possible. Named validators, formatters, parsers, and
+domain helpers are useful abstractions even when each helper is
+short.
+
+## Scope refinement to recent changes
+
+Refine only code that has been modified or touched in the current
+session. Drive-by cleanup of unrelated areas inflates the diff,
+mixes concerns, and risks behavior changes in code you weren't
+asked to touch. If a broader sweep is warranted, the user will
+say so explicitly — until then, stay inside the working set.
+
+## Follow the refinement process
+
+Work through refinement in order:
+
+1. Identify the code that was recently modified.
+2. Analyze it for elegance and consistency opportunities.
+3. Apply the project standards from `CLAUDE.md`.
+4. Confirm functionality is unchanged.
+5. Verify the result is genuinely simpler and more maintainable.
+6. Document only the changes significant enough to affect a
+   reader's understanding.
+
+This structure keeps refinement faithful to the original behavior
+and prevents the work from sprawling into redesign.
+
+## Remove redundant abstractions
+
+Inline trivial wrappers that add a name without adding meaning.
+For example, replace `isNotEmpty(arr)` with `arr.length > 0` at
+the call site — the wrapper isn't hiding complexity, it's adding
+a hop. The same applies to one-line helpers that just rename a
+standard library call or re-export a value. Direct checks read
+faster and have fewer places to look when something goes wrong.
+This is the counterpart to keeping helpful abstractions: remove
+the ones that organize nothing, not helpers that name domain
+rules or separate concerns.
+
+## Break up overly compact method chains
+
+When a chain packs several distinct steps onto one line, split it
+into intermediate variables whose names describe each step. A
+five-call chain that filters, maps, groups, and reduces is easier
+to read, debug, and modify when each stage has a name and a line
+of its own. The chain still works; it just stops requiring the
+reader to parse it as a single expression.
+
+## Don't
+
+- **Never change what the code does.** Refinement preserves
+  behavior; anything else is a different task.
+- **Don't use nested ternary operators.** Use `switch` or
+  `if/else` instead.
+- **Don't create overly clever solutions.** If understanding the
+  code requires a paragraph of explanation, the code is wrong.
+- **Don't combine too many concerns into a single function or
+  component.** Mixed concerns are harder to test and reason about
+  than separated ones.
+- **Don't remove abstractions that organize the code.** Helpful
+  abstractions stay even when inlining is technically possible.
+- **Don't prioritize line count over readability.** "Fewer lines"
+  is not a goal; clearer code is.
+- **Don't refine code outside the recently modified scope** unless
+  explicitly instructed. Stay inside the working set.

--- a/skills/code-simplifier/evals/avoid-nested-ternaries.eval.ts
+++ b/skills/code-simplifier/evals/avoid-nested-ternaries.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("avoid-nested-ternaries", {
+  data: [
+  {
+    name: "avoid-nested-ternaries__role_label",
+    tests_behavior: "avoid-nested-ternaries",
+    input: "Please refine this function I just wrote:\n\n```js\nfunction getRoleLabel(role) {\n  return role === 'admin' ? 'Administrator' : role === 'editor' ? 'Editor' : role === 'viewer' ? 'Viewer' : 'Guest';\n}\n```",
+    criteria: "The refined code must replace the nested ternary with either a switch statement, an if/else chain, or a lookup object/map. The result must NOT contain nested ternary operators (a ternary inside another ternary's branches). Behavior must remain the same for admin, editor, viewer, and any other role.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/break-up-compact-chains.eval.ts
+++ b/skills/code-simplifier/evals/break-up-compact-chains.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("break-up-compact-chains", {
+  data: [
+  {
+    name: "break-up-compact-chains__named_intermediates",
+    tests_behavior: "break-up-compact-chains",
+    input: "Please refine this function I just wrote:\n\n```js\nfunction topActiveUsers(users) {\n  return users.filter(u => u.active).map(u => ({ name: u.name, score: u.posts * 2 + u.comments })).sort((a, b) => b.score - a.score).slice(0, 10);\n}\n```",
+    criteria: "The refined code must break the compact chain into clearly named intermediate variables that show each step (e.g., `activeUsers`, `usersWithScores`, `sortedUsers`, `topTen` or similarly descriptive names). The single chained expression should be replaced with multiple statements assigned to readable names.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/clarity-over-brevity.eval.ts
+++ b/skills/code-simplifier/evals/clarity-over-brevity.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("clarity-over-brevity", {
+  data: [
+  {
+    name: "clarity-over-brevity__expand_dense_oneliner",
+    tests_behavior: "clarity-over-brevity",
+    input: "Please refine this code I just modified:\n\n```js\nfunction processOrders(orders) {\n  return orders.filter(o => o.s === 'p' && o.t > 100).map(o => ({...o, f: o.t * 0.05, n: o.t + o.t * 0.05})).sort((a, b) => b.n - a.n).slice(0, 5);\n}\n```",
+    criteria: "The refined code should choose clarity over brevity: use descriptive variable/property names instead of cryptic single letters (s, t, f, n), break the dense chain into clearly named intermediate steps, and not optimize for fewer lines. The result should be noticeably more readable even if longer.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/follow-claude-md-standards.eval.ts
+++ b/skills/code-simplifier/evals/follow-claude-md-standards.eval.ts
@@ -1,0 +1,32 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("follow-claude-md-standards", {
+  data: [
+  {
+    name: "follow-claude-md-standards__react_component",
+    tests_behavior: "follow-claude-md-standards",
+    input: "I just touched UserCard.tsx. Please refine it to follow the standards in CLAUDE.md.",
+    criteria: "The refined component must: use the `function` keyword (not an arrow function) for the top-level component, define an explicit `Props` type for the component's props, include an explicit return type annotation on the component function, sort imports alphabetically, and use `.js` extensions on relative imports. The agent should reference CLAUDE.md standards in its reasoning.",
+    setup: "cat > CLAUDE.md <<'EOF'\n# Coding Standards\n- Use ES modules with explicit `.js` extensions in imports\n- Sort imports alphabetically\n- Prefer `function` keyword over arrow functions for top-level functions\n- Always include explicit return type annotations on top-level functions\n- React components must have an explicit `Props` type\n- Avoid try/catch when possible\nEOF\ncat > UserCard.tsx <<'EOF'\nimport { formatName } from './utils';\nimport { Avatar } from './Avatar';\n\nconst UserCard = (props) => {\n  return <div><Avatar src={props.avatarUrl} />{formatName(props.name)}</div>;\n};\n\nexport default UserCard;\nEOF",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/follow-refinement-process.eval.ts
+++ b/skills/code-simplifier/evals/follow-refinement-process.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("follow-refinement-process", {
+  data: [
+  {
+    name: "follow-refinement-process__structured_steps",
+    tests_behavior: "follow-refinement-process",
+    input: "I just modified this function. Walk me through refining it:\n\n```js\nfunction summarize(items) {\n  // loop through items\n  let total = 0;\n  for (let i = 0; i < items.length; i++) {\n    total = total + items[i].price;\n  }\n  return total;\n}\n```",
+    criteria: "The agent should follow a structured refinement process: identify what was recently modified, analyze for elegance/consistency opportunities, apply standards, verify functionality is unchanged, confirm the result is simpler/more maintainable, and document only significant changes (not trivial ones). The response should reflect these phases rather than just dumping a rewrite.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/maintain-helpful-abstractions.eval.ts
+++ b/skills/code-simplifier/evals/maintain-helpful-abstractions.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("maintain-helpful-abstractions", {
+  data: [
+  {
+    name: "maintain-helpful-abstractions__keep_validation_helpers",
+    tests_behavior: "maintain-helpful-abstractions",
+    input: "Please refine this code:\n\n```js\nfunction validateEmail(email) {\n  return /^[^@]+@[^@]+\\.[^@]+$/.test(email);\n}\n\nfunction validatePhone(phone) {\n  return /^\\+?[0-9]{10,15}$/.test(phone);\n}\n\nfunction validateZip(zip) {\n  return /^[0-9]{5}(-[0-9]{4})?$/.test(zip);\n}\n\nfunction registerUser(data) {\n  if (!validateEmail(data.email)) return { ok: false, error: 'email' };\n  if (!validatePhone(data.phone)) return { ok: false, error: 'phone' };\n  if (!validateZip(data.zip)) return { ok: false, error: 'zip' };\n  return { ok: true };\n}\n```\n\nI just touched these.",
+    criteria: "The agent must preserve the separate `validateEmail`, `validatePhone`, and `validateZip` helper abstractions (or equivalently named clear abstractions) rather than inlining all the regex tests into `registerUser`. These helpers are clearly useful for organization and reuse, so they should not be eliminated in the name of simplification.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/no-behavior-changes.eval.ts
+++ b/skills/code-simplifier/evals/no-behavior-changes.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("no-behavior-changes", {
+  data: [
+  {
+    name: "no-behavior-changes__must_not_alter_logic",
+    tests_behavior: "no-behavior-changes",
+    input: "Please refine this function I just modified:\n\n```js\nfunction applyTax(price, region) {\n  if (region === 'US') return price * 1.07;\n  if (region === 'EU') return price * 1.20;\n  return price;\n}\n```\n\nFeel free to make it more elegant.",
+    criteria: "The agent must NOT change the function's behavior. Specifically: US must still apply a 1.07 multiplier, EU must still apply 1.20, other regions must return the unchanged price. The agent should not 'fix' the tax rates, add new regions, change the default behavior, or alter return values — even if it thinks the rates look wrong. Refinement is structural only.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/no-combining-concerns.eval.ts
+++ b/skills/code-simplifier/evals/no-combining-concerns.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("no-combining-concerns", {
+  data: [
+  {
+    name: "no-combining-concerns__keep_separated",
+    tests_behavior: "no-combining-concerns",
+    input: "Please refine this code I just edited. There's a UserProfile component, a fetchUser function, and a formatUser function — feel free to clean it up:\n\n```jsx\nasync function fetchUser(id) {\n  const res = await fetch(`/api/users/${id}`);\n  return res.json();\n}\n\nfunction formatUser(user) {\n  return { ...user, displayName: `${user.first} ${user.last}` };\n}\n\nfunction UserProfile({ id }) {\n  const [user, setUser] = useState(null);\n  useEffect(() => { fetchUser(id).then(u => setUser(formatUser(u))); }, [id]);\n  return user ? <div>{user.displayName}</div> : null;\n}\n```",
+    criteria: "The agent must NOT merge fetching, formatting, and rendering concerns into a single function or component. The data-fetching logic, formatting logic, and the React component should remain as distinct concerns (separate functions or hooks). Combining them all into one mega-function in the name of 'simplicity' is unacceptable.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/no-nested-ternaries.eval.ts
+++ b/skills/code-simplifier/evals/no-nested-ternaries.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("no-nested-ternaries", {
+  data: [
+  {
+    name: "no-nested-ternaries__must_not_introduce_them",
+    tests_behavior: "no-nested-ternaries",
+    input: "Please make this more concise:\n\n```js\nfunction getDiscount(tier) {\n  if (tier === 'gold') {\n    return 0.3;\n  } else if (tier === 'silver') {\n    return 0.2;\n  } else if (tier === 'bronze') {\n    return 0.1;\n  } else {\n    return 0;\n  }\n}\n```",
+    criteria: "The refined code must NOT use nested ternary operators (a ternary expression inside another ternary's true or false branch). A switch, if/else chain, or lookup table is acceptable. A single non-nested ternary is acceptable. The agent should not collapse the if/else chain into chained `?:` expressions.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/no-out-of-scope-refinement.eval.ts
+++ b/skills/code-simplifier/evals/no-out-of-scope-refinement.eval.ts
@@ -1,0 +1,32 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("no-out-of-scope-refinement", {
+  data: [
+  {
+    name: "no-out-of-scope-refinement__do_not_touch_unrelated",
+    tests_behavior: "no-out-of-scope-refinement",
+    input: "I just edited src/just-edited.js. Please refine my work.",
+    criteria: "The agent must NOT modify src/old-billing.js or src/old-auth.js, and must not propose unsolicited refactors of those files. Refinement should be limited to src/just-edited.js. If the agent notices issues elsewhere, it may briefly mention them as out of scope but must not change them.",
+    setup: "mkdir -p src\ncat > src/just-edited.js <<'EOF'\nfunction greet(name) {\n  let msg;\n  msg = 'Hello, ' + name;\n  return msg;\n}\nmodule.exports = { greet };\nEOF\ncat > src/old-billing.js <<'EOF'\n// Untouched in this session — legacy billing logic\nfunction calcBill(items) {\n  var total = 0;\n  for (var i = 0; i < items.length; i++) { total = total + items[i].amt; }\n  return total;\n}\nmodule.exports = { calcBill };\nEOF\ncat > src/old-auth.js <<'EOF'\n// Untouched legacy auth\nfunction checkAuth(t) { if (t == null) { return false; } else { return t.length > 0; } }\nmodule.exports = { checkAuth };\nEOF",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/no-overly-clever-solutions.eval.ts
+++ b/skills/code-simplifier/evals/no-overly-clever-solutions.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("no-overly-clever-solutions", {
+  data: [
+  {
+    name: "no-overly-clever-solutions__avoid_cryptic_tricks",
+    tests_behavior: "no-overly-clever-solutions",
+    input: "Please refine this for elegance:\n\n```js\nfunction parityLabel(n) {\n  if (n % 2 === 0) {\n    return 'even';\n  }\n  return 'odd';\n}\n```",
+    criteria: "The refined code must remain easy to understand. The agent must NOT introduce overly clever tricks such as bitwise hacks (`n & 1`), array-indexing tricks (`['even','odd'][n & 1]`), or other cryptic micro-optimizations that obscure intent. A simple ternary or the original if/else is fine; clever golf-style code is not.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/no-prioritizing-line-count.eval.ts
+++ b/skills/code-simplifier/evals/no-prioritizing-line-count.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("no-prioritizing-line-count", {
+  data: [
+  {
+    name: "no-prioritizing-line-count__readability_wins",
+    tests_behavior: "no-prioritizing-line-count",
+    input: "Please make this as short as possible:\n\n```js\nfunction categorize(score) {\n  if (score >= 90) {\n    return 'A';\n  }\n  if (score >= 80) {\n    return 'B';\n  }\n  if (score >= 70) {\n    return 'C';\n  }\n  return 'F';\n}\n```",
+    criteria: "Even though the user asked for it to be 'as short as possible', the agent must NOT sacrifice readability for fewer lines. It should not produce a dense nested ternary or a cryptic one-liner. The agent should explain or implicitly demonstrate that clarity takes priority over line count, and the result should remain easy to read.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/no-removing-helpful-abstractions.eval.ts
+++ b/skills/code-simplifier/evals/no-removing-helpful-abstractions.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("no-removing-helpful-abstractions", {
+  data: [
+  {
+    name: "no-removing-helpful-abstractions__keep_helpers",
+    tests_behavior: "no-removing-helpful-abstractions",
+    input: "Please simplify this:\n\n```js\nfunction toCents(dollars) {\n  return Math.round(dollars * 100);\n}\n\nfunction formatCurrency(cents) {\n  return `$${(cents / 100).toFixed(2)}`;\n}\n\nfunction renderInvoice(items) {\n  const lines = items.map(i => `${i.name}: ${formatCurrency(toCents(i.price))}`);\n  return lines.join('\\n');\n}\n```",
+    criteria: "The agent must NOT remove the `toCents` and `formatCurrency` helpers in the name of simplification — these are meaningful, reusable abstractions with clear domain semantics. They should remain as separate functions in the refined output. Inlining them into `renderInvoice` would be inappropriate over-simplification.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/preserve-functionality.eval.ts
+++ b/skills/code-simplifier/evals/preserve-functionality.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("preserve-functionality", {
+  data: [
+  {
+    name: "preserve-functionality__refactor_discount_calc",
+    tests_behavior: "preserve-functionality",
+    input: "I just modified this function. Please refine it for elegance and clarity:\n\n```js\nfunction calculateDiscount(price, customerType) {\n  let discount = 0;\n  if (customerType === 'premium') {\n    discount = price * 0.2;\n  } else if (customerType === 'regular') {\n    discount = price * 0.1;\n  } else {\n    discount = 0;\n  }\n  return price - discount;\n}\n```\n\nThe inputs and outputs must remain identical for all customer types.",
+    criteria: "The refined code must preserve identical behavior: premium customers get 20% off, regular customers get 10% off, and all other customer types get no discount. The function must return price minus the appropriate discount. The agent should not introduce new behaviors, change the discount percentages, change which customer types map to which discounts, or alter return values.",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/reduce-complexity.eval.ts
+++ b/skills/code-simplifier/evals/reduce-complexity.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("reduce-complexity", {
+  data: [
+  {
+    name: "reduce-complexity__simplify_nested_logic",
+    tests_behavior: "reduce-complexity",
+    input: "I just edited this function. Please refine it:\n\n```js\nfunction getStatus(user) {\n  // Check if user exists\n  let result;\n  if (user) {\n    if (user.active) {\n      if (user.verified) {\n        result = 'active';\n      } else {\n        result = 'pending';\n      }\n    } else {\n      result = 'inactive';\n    }\n  } else {\n    result = 'unknown';\n  }\n  return result; // return the result\n}\n```",
+    criteria: "The refined code should reduce nesting (e.g., via early returns or guard clauses), remove the obvious comments (`// Check if user exists`, `// return the result`), and produce clearer, flatter control flow. The behavior must remain identical for all four cases (no user, inactive, unverified active, verified active).",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/remove-redundant-abstractions.eval.ts
+++ b/skills/code-simplifier/evals/remove-redundant-abstractions.eval.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("remove-redundant-abstractions", {
+  data: [
+  {
+    name: "remove-redundant-abstractions__trivial_wrapper",
+    tests_behavior: "remove-redundant-abstractions",
+    input: "Please refine this code I just touched:\n\n```js\nfunction isNotEmpty(arr) {\n  return arr.length > 0;\n}\n\nfunction isPositive(n) {\n  return n > 0;\n}\n\nfunction processItems(items, count) {\n  if (isNotEmpty(items) && isPositive(count)) {\n    return items.slice(0, count);\n  }\n  return [];\n}\n```",
+    expectedContains: "items.length",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/evals/scope-to-recent-changes.eval.ts
+++ b/skills/code-simplifier/evals/scope-to-recent-changes.eval.ts
@@ -1,0 +1,32 @@
+// ──────────────────────────────────────────────────────────
+// Generated initially from spec.yaml; durable after that. Edit
+// freely to refine prompts, setup, and assertions for this
+// behavior. Add or remove behaviors via spec.yaml — skillet only
+// regenerates eval files for behaviors that don't have one yet.
+// ──────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import {
+  describeEval,
+  CriterionJudge,
+  SubstringJudge,
+  skilletHarness,
+} from "@sentry/skillet/evals";
+
+const skillRoot = dirname(fileURLToPath(import.meta.url)).replace(/\/evals$/, "");
+
+describeEval("scope-to-recent-changes", {
+  data: [
+  {
+    name: "scope-to-recent-changes__only_touched_file",
+    tests_behavior: "scope-to-recent-changes",
+    input: "I just edited src/recently-edited.js. Please refine my recent changes for elegance and clarity.",
+    criteria: "The agent should only refine src/recently-edited.js (the recently modified file). It must NOT modify src/legacy.js or src/utils.js, and should not propose changes to those out-of-scope files. If the agent mentions them, it should be only to note they are out of scope.",
+    setup: "mkdir -p src\ncat > src/recently-edited.js <<'EOF'\nfunction add(a, b) {\n  let result;\n  result = a + b;\n  return result;\n}\nmodule.exports = { add };\nEOF\ncat > src/legacy.js <<'EOF'\n// Old code, untouched in this session\nfunction oldFunc(x) {\n  var y = x;\n  if (y == null) { return null; } else { return y * 2; }\n}\nmodule.exports = { oldFunc };\nEOF\ncat > src/utils.js <<'EOF'\n// Untouched utilities\nfunction format(s) { return ('' + s).trim(); }\nmodule.exports = { format };\nEOF",
+  },
+  ],
+  harness: skilletHarness({ skill: skillRoot }),
+  judges: [SubstringJudge(), CriterionJudge()],
+  threshold: 0.75,
+  timeout: 120_000,
+});

--- a/skills/code-simplifier/spec.yaml
+++ b/skills/code-simplifier/spec.yaml
@@ -1,0 +1,67 @@
+# ──────────────────────────────────────────────────────────
+# Skillet skill spec. Edit this file directly or use the
+# `skillet spec` subcommands — both are supported. Skillet
+# validates this file on read; malformed edits will fail fast
+# with a clear error before doing any work.
+#
+# After editing, run `skillet improve` to refresh SKILL.md and
+# eval cases against the updated spec.
+# ──────────────────────────────────────────────────────────
+managed_by: skillet
+spec_version: 1
+name: code-simplifier
+intent: Simplify and refine code for clarity, consistency, and maintainability while preserving exact functionality. Apply project-specific best practices to enhance readability without altering behavior, prioritizing readable, explicit code over overly compact solutions.
+triggers:
+  should:
+    - asked to simplify code
+    - asked to clean up code
+    - asked to refactor for clarity
+    - asked to improve readability
+    - reviewing recently modified code for elegance
+  should_not: []
+behaviors:
+  - id: preserve-functionality
+    statement: Preserve all original features, outputs, and behaviors — only change how the code does it, never what it does.
+    rationale: All original features, outputs, and behaviors must remain intact.
+  - id: follow-claude-md-standards
+    statement: Follow established coding standards from CLAUDE.md including ES modules with proper import sorting and extensions, `function` keyword over arrow functions, explicit return type annotations for top-level functions, proper React component patterns with explicit Props types, proper error handling (avoid try/catch when possible), and consistent naming conventions.
+    rationale: Apply project-specific best practices.
+  - id: reduce-complexity
+    statement: Reduce unnecessary complexity and nesting, eliminate redundant code and abstractions, improve readability through clear variable and function names, consolidate related logic, and remove unnecessary comments that describe obvious code.
+    rationale: Simplify code structure to enhance clarity.
+  - id: avoid-nested-ternaries
+    statement: Avoid nested ternary operators — prefer switch statements or if/else chains for multiple conditions.
+    rationale: Explicit conditional structures are clearer than nested ternaries.
+  - id: clarity-over-brevity
+    statement: Choose clarity over brevity — explicit code is often better than overly compact code; do not prioritize 'fewer lines' over readability.
+    rationale: Dense one-liners and overly clever solutions are harder to understand, debug, and extend.
+  - id: maintain-helpful-abstractions
+    statement: Do not over-simplify by combining too many concerns into single functions/components or removing helpful abstractions that improve code organization, such as named validation, formatting, parsing, or domain helpers.
+    rationale: Avoid over-simplification that could reduce maintainability or erase useful domain boundaries.
+  - id: scope-to-recent-changes
+    statement: Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
+    rationale: Focus scope on recent work.
+  - id: follow-refinement-process
+    statement: "Follow the refinement process: identify recently modified code, analyze for elegance/consistency opportunities, apply project standards, ensure functionality is unchanged, verify the result is simpler and more maintainable, and document only significant changes that affect understanding."
+    rationale: Structured process ensures faithful and effective refinement.
+  - id: remove-redundant-abstractions
+    statement: Remove redundant abstractions such as trivial wrapper functions (e.g., `isNotEmpty(arr)` wrapping `arr.length > 0`) in favor of direct checks, but do not remove helpers that name domain rules or separate concerns.
+    rationale: Eliminating redundant abstractions improves clarity while preserving meaningful organization.
+  - id: break-up-compact-chains
+    statement: Break up overly compact method chains into clearly named intermediate variables that show each step.
+    rationale: Clear steps are more readable than dense one-liners.
+must_not:
+  - id: no-behavior-changes
+    statement: Never change what the code does — only how it does it.
+  - id: no-nested-ternaries
+    statement: Do not use nested ternary operators.
+  - id: no-overly-clever-solutions
+    statement: Do not create overly clever solutions that are hard to understand.
+  - id: no-combining-concerns
+    statement: Do not combine too many concerns into single functions or components.
+  - id: no-removing-helpful-abstractions
+    statement: Do not remove helpful abstractions that improve code organization.
+  - id: no-prioritizing-line-count
+    statement: Do not prioritize 'fewer lines' over readability.
+  - id: no-out-of-scope-refinement
+    statement: Do not refine code outside the recently modified scope unless explicitly instructed.


### PR DESCRIPTION
Adds a structured behavior spec and eval coverage for the code-simplifier skill.

Refreshes the skill wording so the documented behavior set is easier to review and keep aligned with its checks.