### PR TITLE
feat(gocd-deploy-status): add read-only GoCD pipeline status skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,7 @@
       "Skill(sentry-skills:find-bugs)",
       "Skill(sentry-skills:gh-review-requests)",
       "Skill(sentry-skills:gha-security-review)",
+      "Skill(sentry-skills:gocd-deploy-status)",
       "Skill(sentry-skills:iterate-pr)",
       "Skill(sentry-skills:pr-writer)",
       "Skill(sentry-skills:security-review)",

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Works with Claude Code, Cursor, Cline, GitHub Copilot, and other compatible agen
 | [find-bugs](plugins/sentry-skills/skills/find-bugs/SKILL.md) | Find bugs, security vulnerabilities, and code quality issues in local branch changes. |
 | [gh-review-requests](plugins/sentry-skills/skills/gh-review-requests/SKILL.md) | Fetch unread GitHub notifications for open PRs where review is requested from a specified team or opened by a team member. |
 | [gha-security-review](plugins/sentry-skills/skills/gha-security-review/SKILL.md) | GitHub Actions security review for workflow exploitation vulnerabilities. |
+| [gocd-deploy-status](plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md) | Read-only access to GoCD deployment pipelines at Sentry. Query pipeline status, fetch deploy logs, and view build history. |
 | [iterate-pr](plugins/sentry-skills/skills/iterate-pr/SKILL.md) | Iterate on a PR until CI passes. |
 | [pr-writer](plugins/sentry-skills/skills/pr-writer/SKILL.md) | Canonical workflow to create and update pull requests following Sentry conventions. |
 | [security-review](plugins/sentry-skills/skills/security-review/SKILL.md) | Security code review for vulnerabilities. |

--- a/plugins/sentry-skills/skills/claude-settings-audit/SKILL.md
+++ b/plugins/sentry-skills/skills/claude-settings-audit/SKILL.md
@@ -156,6 +156,7 @@ If this is a Sentry project (or sentry-skills plugin is installed), include:
   "Skill(sentry-skills:find-bugs)",
   "Skill(sentry-skills:gh-review-requests)",
   "Skill(sentry-skills:gha-security-review)",
+  "Skill(sentry-skills:gocd-deploy-status)",
   "Skill(sentry-skills:iterate-pr)",
   "Skill(sentry-skills:pr-writer)",
   "Skill(sentry-skills:security-review)",

--- a/plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md
@@ -64,9 +64,37 @@ When `failures` returns `log_status: "archived"`, the run is older than ~30 days
 
 ## Authentication
 
-The skill fetches the GoCD token from GCP Secret Manager (`gocd-access-token` in `dicd-team-devinfra-cd`) and mints an IAP identity token via service account impersonation. To use a personal read-only token instead, set `GOCD_ACCESS_TOKEN` -- it takes precedence over the Secret Manager fetch.
+Two tokens are needed: a GoCD bearer token and a Google IAP identity token. The IAP token is minted automatically via service account impersonation (no setup needed beyond `gcloud auth login` + `role-deploy-user@sentry.io` membership). For the GoCD token there are two paths:
 
-See [references/gocd_skill_auth.md](references/gocd_skill_auth.md) for the full auth flow.
+1. **Default**: fetched from GCP Secret Manager (`gocd-access-token` in `dicd-team-devinfra-cd`). Admin-scoped; anyone with project access can read it. Works out of the box, no setup.
+2. **Personal read-only token (preferred)**: mint your own from GoCD's UI. Smaller blast radius (read-only enforced server-side) and produces per-user audit trails on the GoCD side.
+
+### First-time setup with a personal read-only token
+
+1. Open https://deploy.getsentry.net in your browser. Click your avatar (top right) → "Personal Access Tokens".
+2. Click "Generate Token". Give it a name like `claude-code-readonly`. Copy the value -- GoCD only shows it once.
+3. Make `GOCD_ACCESS_TOKEN` available in the shell where Claude Code runs. Pick whichever fits your workflow:
+
+   **Shell rc file (simplest, persistent):**
+   ```bash
+   echo 'export GOCD_ACCESS_TOKEN=<your-token>' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+
+   **Project-local `.env` with `direnv`:**
+   ```bash
+   echo 'export GOCD_ACCESS_TOKEN=<your-token>' >> .envrc
+   direnv allow
+   ```
+
+   **Inline for one-off use:**
+   ```bash
+   GOCD_ACCESS_TOKEN=<your-token> uv run ${CLAUDE_SKILL_ROOT}/scripts/gocd.py status getsentry-backend
+   ```
+
+When `GOCD_ACCESS_TOKEN` is set, the skill skips Secret Manager entirely. Tokens don't auto-expire; rotate manually via the same GoCD UI when needed.
+
+See [references/gocd_skill_auth.md](references/gocd_skill_auth.md) for the full auth flow including how IAP impersonation works.
 
 ## Errors
 

--- a/plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: gocd-deploy-status
+description: >
+  Read-only access to GoCD deployment pipelines at Sentry. Query pipeline status,
+  fetch deploy logs, and view build history. Use when asked about "deployments",
+  "deploy status", "pipeline status", "deploy logs", "build failures", "what's
+  deploying", "why did the deploy fail", "gocd", "pipeline", "canary", "stage
+  failed", "build broken", "what's deploying right now", or "check deploy progress".
+allowed-tools: Read, Bash, Grep
+---
+
+# GoCD Deploy Status (Read-Only)
+
+This skill queries GoCD pipelines at Sentry. It cannot trigger, pause, or otherwise modify them -- mutating actions go through the GoCD web UI or someone with `role-deploy-operator@sentry.io`.
+
+## Requirements
+
+- `gcloud` authenticated (`gcloud auth login`) with an account in `role-deploy-user@sentry.io` (same group that gates the GoCD web UI).
+- `uv` installed: https://docs.astral.sh/uv/getting-started/installation/
+
+## Commands
+
+Run all commands with `uv run ${CLAUDE_SKILL_ROOT}/scripts/gocd.py <cmd>`:
+
+| Command | What it does |
+|---|---|
+| `pipelines` | List all pipeline groups |
+| `status <name>` | Status of a pipeline or pipeline group |
+| `history <pipeline> [--count N]` | Recent runs (default 5) |
+| `stage <pipeline> <pctr> <stage> <sctr>` | Stage instance details |
+| `job-log <pipeline> <pctr> <stage> <sctr> <job> [--tail N]` | Console log (default last 200 lines) |
+
+The `status` command resolves `<name>` as either a pipeline or a group; group output wraps multiple pipeline statuses.
+
+## Domain Model
+
+- **Pipeline group** ("pipedream"): related pipelines for a deploy target, e.g. `getsentry-backend` contains `deploy-getsentry-backend-us`, `deploy-getsentry-backend-de`, `rollback-getsentry-backend`.
+- **Pipeline**: a deploy target with stages (e.g. `migrations`, `deploy-canary`, `deploy-primary`).
+- **Stage**: a step within a pipeline run; contains jobs.
+- **Job**: a unit of work with a console log.
+
+## Workflows
+
+**"Why did the deploy fail?"**
+
+1. `status <pipeline>` -- find the failed stage
+2. `stage <pipeline> <counter> <failed_stage> 1` -- find the failed job
+3. `job-log <pipeline> <counter> <failed_stage> 1 <failed_job> --tail 200` -- read the error
+
+**"What's deploying right now?"**
+
+1. `pipelines` to list groups
+2. `status <group>` -- look for `"locked": true` (active run) or stages with `"status": "Building"`
+
+**"Roll back a deploy"**: not supported here. Use the GoCD web UI or ask someone with `role-deploy-operator@sentry.io`.
+
+## Authentication
+
+The skill fetches the GoCD token from GCP Secret Manager (`gocd-access-token` in `dicd-team-devinfra-cd`) and mints an IAP identity token via service account impersonation. To use a personal read-only token instead, set `GOCD_ACCESS_TOKEN` -- it takes precedence over the Secret Manager fetch.
+
+See [references/gocd_skill_auth.md](references/gocd_skill_auth.md) for the full auth flow.
+
+## Errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `could not get IAP token` | Not in `role-deploy-user@sentry.io` | Get added to the group |
+| `HTTP 401` | Invalid GoCD token | Check `GOCD_ACCESS_TOKEN`, or the GCP secret |
+| `HTTP 403` | IAP token invalid, or token lacks read permission | `gcloud auth login`; if using personal token, confirm it has the view role |
+| `HTTP 404` | Pipeline/stage name typo | Check with `pipelines` |
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `GOCD_HOST` | `https://deploy.getsentry.net` | GoCD server URL |
+| `GOCD_ACCESS_TOKEN` | (unset) | Personal read-only token; overrides Secret Manager |
+| `GOCD_IAP_CLIENT_ID` | Sentry's IAP client | IAP audience |
+| `GOCD_IAP_SERVICE_ACCOUNT` | Sentry's impersonated SA | SA for IAP token minting |
+
+For curl-based fallback and full API details, see [references/api-surface.md](references/api-surface.md).

--- a/plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: gocd-deploy-status
-description: >
-  Read-only access to GoCD deployment pipelines at Sentry. Query pipeline status,
-  fetch deploy logs, and view build history. Use when asked about "deployments",
-  "deploy status", "pipeline status", "deploy logs", "build failures", "what's
-  deploying", "why did the deploy fail", "gocd", "pipeline", "canary", "stage
-  failed", "build broken", "what's deploying right now", or "check deploy progress".
-allowed-tools: Read, Bash, Grep
+description: Read-only access to GoCD deployment pipelines at Sentry. Query pipeline status, fetch deploy logs, view build history, and find which pipeline runs include a given commit SHA. Use when asked about deployments, deploy status, pipeline status, deploy logs, build failures, what's deploying, why did the deploy fail, did my commit ship, gocd, pipeline, canary, stage failed, build broken, or check deploy progress.
 ---
 
 # GoCD Deploy Status (Read-Only)
 
-This skill queries GoCD pipelines at Sentry. It cannot trigger, pause, or otherwise modify them -- mutating actions go through the GoCD web UI or someone with `role-deploy-operator@sentry.io`.
+This skill is the drill-in tool for GoCD deploy questions -- engineers usually start from a Slack notification (eng-pipes posts "your commit shipped" / "no deploys in 2h" / "consecutive failures") and reach for this skill when they need detail. It cannot trigger, pause, or otherwise modify pipelines; that goes through the GoCD web UI or someone with `role-deploy-operator@sentry.io`.
 
 ## Requirements
 
@@ -28,29 +22,40 @@ Run all commands with `uv run ${CLAUDE_SKILL_ROOT}/scripts/gocd.py <cmd>`:
 | `status <name>` | Status of a pipeline or pipeline group |
 | `history <pipeline> [--count N]` | Recent runs (default 5) |
 | `stage <pipeline> <pctr> <stage> <sctr>` | Stage instance details |
-| `job-log <pipeline> <pctr> <stage> <sctr> <job> [--tail N]` | Console log (default last 200 lines) |
+| `job-log <pipeline> <pctr> <stage> <sctr> <job> [--tail N] [--full]` | Console log; smart-deduped by default |
+| `find-deploy <sha> <pipeline-or-group> [--count N]` | Find runs containing a commit SHA |
+| `failures <pipeline-or-group> [--count N]` | Recent failed runs with failed-job log excerpt |
 
-The `status` command resolves `<name>` as either a pipeline or a group; group output wraps multiple pipeline statuses.
+The `status`, `find-deploy`, and `failures` commands resolve `<name>` as either a pipeline or a group; group output wraps results from each pipeline in the group.
+
+`job-log` defaults to a smart-truncated view: consecutive lines that differ only in digit fields (timestamps, counters, host indices) are collapsed. Pass `--full` to fetch the entire raw log without dedup or tail.
 
 ## Domain Model
 
-- **Pipeline group** ("pipedream"): related pipelines for a deploy target, e.g. `getsentry-backend` contains `deploy-getsentry-backend-us`, `deploy-getsentry-backend-de`, `rollback-getsentry-backend`.
-- **Pipeline**: a deploy target with stages (e.g. `migrations`, `deploy-canary`, `deploy-primary`).
+- **Pipeline group** ("pipedream"): related pipelines for a deploy target, e.g. `getsentry-backend` contains `deploy-getsentry-backend-us`, `deploy-getsentry-backend-de`, `deploy-getsentry-backend-s4s2`, `rollback-getsentry-backend`. Other common pipedreams: `getsentry-frontend`, `sentry-saas`, `relay`, `snuba`, `seer`, `taskbroker`, `vroom`.
+- **Pipeline**: a deploy target with stages (e.g. `checks`, `migrations`, `deploy-canary`, `deploy-primary`, `pipeline-complete`). `pipeline-complete` marks the run finished -- use it when checking "did the deploy actually finish?"
+- **Region suffixes** on pipeline names: `-us`, `-de`, `-s4s` / `-s4s2` (single-tenant), `-control`, `-customer-N` (per-customer single tenants), `-st`.
 - **Stage**: a step within a pipeline run; contains jobs.
 - **Job**: a unit of work with a console log.
 
 ## Workflows
 
-**"Why did the deploy fail?"**
+**"Did my commit ship?"**
 
-1. `status <pipeline>` -- find the failed stage
-2. `stage <pipeline> <counter> <failed_stage> 1` -- find the failed job
-3. `job-log <pipeline> <counter> <failed_stage> 1 <failed_job> --tail 200` -- read the error
+`find-deploy <sha> <group>` -- e.g. `find-deploy 77f89b7e getsentry-backend`. Returns each pipeline run in the search window that includes the SHA, with stage statuses. If no matches, the SHA either hasn't entered the pipeline yet or is older than the search window (`--count` controls window size, default 20 runs per pipeline).
+
+**"What's broken?" / "Why did the deploy fail?"**
+
+`failures <group>` -- one call returns recent failed runs across the group, each with the failed stage, failed jobs, and last 50 lines of the first failed job's console log (deduped). For the full log on a specific job, follow up with `job-log ... --full`.
+
+**"Why is this pipeline paused?"**
+
+Sentry's deploy scripts auto-pause pipelines when canary fails (see `getsentry/gocd/templates/bash/backend/rollback-canary-and-pause.sh`). When `status` shows `paused: true`, check `paused_cause` and run `failures <pipeline>` -- the most recent failed run usually has the answer.
 
 **"What's deploying right now?"**
 
-1. `pipelines` to list groups
-2. `status <group>` -- look for `"locked": true` (active run) or stages with `"status": "Building"`
+1. `status <group>` -- look for `"locked": true` (active run) or stages with `"status": "Building"`.
+2. A run that looks "stuck" for a few minutes in `deploy-canary` or `soak-time` is normal -- those stages have intentional 5-minute soak windows.
 
 **"Roll back a deploy"**: not supported here. Use the GoCD web UI or ask someone with `role-deploy-operator@sentry.io`.
 
@@ -79,3 +84,7 @@ See [references/gocd_skill_auth.md](references/gocd_skill_auth.md) for the full 
 | `GOCD_IAP_SERVICE_ACCOUNT` | Sentry's impersonated SA | SA for IAP token minting |
 
 For curl-based fallback and full API details, see [references/api-surface.md](references/api-surface.md).
+
+Internal Sentry references:
+- [Pipedreams in GoCD with Jsonnet](https://www.notion.so/sentry/Pipedreams-in-GoCD-with-Jsonnet-430f46b87fa14650a80adf6708b088d9) -- canonical pipedream model (linked from `getsentry/gocd/templates/backend.jsonnet`)
+- [GoCD New Service Quickstart](https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d) -- adding a new service to GoCD

--- a/plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/SKILL.md
@@ -25,6 +25,7 @@ Run all commands with `uv run ${CLAUDE_SKILL_ROOT}/scripts/gocd.py <cmd>`:
 | `job-log <pipeline> <pctr> <stage> <sctr> <job> [--tail N] [--full]` | Console log; smart-deduped by default |
 | `find-deploy <sha> <pipeline-or-group> [--count N]` | Find runs containing a commit SHA |
 | `failures <pipeline-or-group> [--count N]` | Recent failed runs with failed-job log excerpt |
+| `paused [group]` | List currently-paused pipelines; scope to a group or scan all |
 
 The `status`, `find-deploy`, and `failures` commands resolve `<name>` as either a pipeline or a group; group output wraps results from each pipeline in the group.
 
@@ -48,9 +49,11 @@ The `status`, `find-deploy`, and `failures` commands resolve `<name>` as either 
 
 `failures <group>` -- one call returns recent failed runs across the group, each with the failed stage, failed jobs, and last 50 lines of the first failed job's console log (deduped). For the full log on a specific job, follow up with `job-log ... --full`.
 
-**"Why is this pipeline paused?"**
+**"What's paused right now?"**
 
-Sentry's deploy scripts auto-pause pipelines when canary fails (see `getsentry/gocd/templates/bash/backend/rollback-canary-and-pause.sh`). When `status` shows `paused: true`, check `paused_cause` and run `failures <pipeline>` -- the most recent failed run usually has the answer.
+`paused [group]` -- scope to a group (e.g. `paused getsentry-backend`) or omit to scan everything. Returns each paused pipeline with `paused_by` and `paused_cause`. Sentry's deploy scripts auto-pause pipelines when canary fails (see `getsentry/gocd/templates/bash/backend/rollback-canary-and-pause.sh`), so a paused pipeline often means something broke -- follow up with `failures <pipeline>` to see why.
+
+When `failures` returns `log_status: "archived"`, the run is older than ~30 days and its logs were moved to GCS; for those, fall back to the GoCD web UI.
 
 **"What's deploying right now?"**
 

--- a/plugins/sentry-skills/skills/gocd-deploy-status/references/api-surface.md
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/references/api-surface.md
@@ -1,0 +1,95 @@
+# GoCD REST API Reference (Read-Only)
+
+This reference documents the read endpoints used by the gocd-deploy skill. Mutating
+endpoints (schedule, pause, unpause, cancel, run) are intentionally omitted -- this
+skill is read-only.
+
+## Authentication
+
+Every request to `deploy.getsentry.net` requires two headers:
+
+```
+Authorization: bearer <GOCD_ACCESS_TOKEN>
+Proxy-Authorization: Bearer <IAP_ID_TOKEN>
+```
+
+## Endpoints
+
+### Pipeline History (paginated)
+
+```
+GET /go/api/pipelines/{name}/history?page_size=N&after=CURSOR
+Accept: application/vnd.go.cd.v1+json
+```
+
+Pagination is cursor-based via `_links.next.href`. Extract the query string from the next href and append to the next call. Absent `_links.next` means last page.
+
+Response fields per pipeline run:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Pipeline name |
+| `counter` | int | Run number |
+| `scheduled_date` | int | Unix timestamp in milliseconds |
+| `build_cause.material_revisions[]` | array | Git SHAs, pipeline dependencies |
+| `stages[]` | array | Stage name, status, counter, jobs |
+
+Stage `status` values: `Building`, `Passed`, `Failed`, `Unknown`.
+Job `state` values: `Scheduled`, `Building`, `Completed`.
+Job `result` values: `Passed`, `Failed`.
+
+### Pipeline Instance
+
+```
+GET /go/api/pipelines/{name}/{counter}
+Accept: application/vnd.go.cd.v1+json
+```
+
+Same structure as a single entry in the history response.
+
+### Pipeline Status
+
+```
+GET /go/api/pipelines/{name}/status
+Accept: application/vnd.go.cd.v1+json
+```
+
+```json
+{"paused": false, "paused_cause": "", "paused_by": "", "locked": true, "schedulable": false}
+```
+
+A pipeline is actively running when `locked: true` and `schedulable: false`.
+
+### Pipeline Groups
+
+```
+GET /go/api/config/pipeline_groups
+Accept: application/vnd.go.cd.v1+json
+```
+
+Returns array of `{name, pipelines: [{name, ...}]}`.
+
+### Stage Instance
+
+```
+GET /go/api/stages/{pipeline}/{pipeline_counter}/{stage}/{stage_counter}
+Accept: application/vnd.go.cd.v3+json
+```
+
+Returns detailed job information including `job_state_transitions` with timestamps for: `Scheduled`, `Assigned`, `Preparing`, `Building`, `Completing`, `Completed`.
+
+### Job Console Log
+
+```
+GET /go/files/{pipeline}/{counter}/{stage}/{stage_counter}/{job}/cruise-output/console.log
+```
+
+Returns plain text (not JSON). No `Accept` header needed. All path segments are required.
+
+Console logs are stored on the GoCD server's persistent volume. Logs older than 30 days are archived to GCS and deleted from disk.
+
+## Domain Concepts
+
+**Pipeline locator**: `{pipeline}/{counter}/{stage}/{stage_counter}` -- e.g. `deploy-getsentry-backend-us/13954/deploy-primary/1`. Appears in `GO_DEPENDENCY_LOCATOR_*` env vars and in Pipeline-type material revisions.
+
+**Pipeline groups**: Pipelines are organized into groups (e.g., `getsentry-backend`, `sentry-saas`). Config repos in GitHub define the pipeline YAML for each group.

--- a/plugins/sentry-skills/skills/gocd-deploy-status/references/api-surface.md
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/references/api-surface.md
@@ -63,11 +63,13 @@ A pipeline is actively running when `locked: true` and `schedulable: false`.
 ### Pipeline Groups
 
 ```
-GET /go/api/config/pipeline_groups
+GET /go/api/admin/pipeline_groups
 Accept: application/vnd.go.cd.v1+json
 ```
 
-Returns array of `{name, pipelines: [{name, ...}]}`.
+Returns `{_embedded: {groups: [{name, pipelines: [{name, ...}], ...}]}}`.
+
+Note: `page_size` on `/go/api/pipelines/{name}/history` has a server-side minimum of 10 -- requests below that return HTTP 404. Clamp the request and slice client-side.
 
 ### Stage Instance
 

--- a/plugins/sentry-skills/skills/gocd-deploy-status/references/gocd_skill_auth.md
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/references/gocd_skill_auth.md
@@ -1,0 +1,96 @@
+# GoCD Skill Authentication
+
+## Overview
+
+The GoCD skill authenticates through two layers:
+
+1. **IAP (Identity-Aware Proxy)** — Google's reverse proxy that protects `deploy.getsentry.net`. Every request must carry a valid OIDC identity token.
+2. **GoCD API token** — A bearer token that authenticates the caller to the GoCD application itself.
+
+Both are obtained via `gcloud` — engineers only need `gcloud auth login` with their `@sentry.io` account.
+
+## GoCD API Token
+
+Default source: GCP Secret Manager.
+
+- **Project**: `dicd-team-devinfra-cd`
+- **Secret**: `gocd-access-token`
+- **Retrieved via**: `gcloud secrets versions access latest --secret=gocd-access-token --project=dicd-team-devinfra-cd`
+
+Any engineer with access to the `dicd-team-devinfra-cd` project can read this secret.
+
+### Override via env var
+
+If `GOCD_ACCESS_TOKEN` is set in the environment, the skill uses that value instead of fetching from Secret Manager. This is the recommended path for engineers running with a personal read-only token minted from their own GoCD account -- it scopes blast radius to view-only operations and produces per-user audit trails on the GoCD side.
+
+## IAP Authentication via Service Account Impersonation
+
+### Why impersonation?
+
+Google Cloud IAP requires an OIDC identity token whose `aud` (audience) claim matches the IAP backend client ID. For user accounts, `gcloud auth print-identity-token --audiences=...` is not supported — the `--audiences` flag only works for service accounts.
+
+The standard workaround is **service account impersonation**: the engineer's own credentials are used to call the IAM API, which mints an identity token on behalf of a service account that has IAP access.
+
+### How it works
+
+```
+Engineer (ming.chen@sentry.io)
+    │
+    ├─ gcloud auth login  (authenticates as themselves)
+    │
+    └─ gcloud auth print-identity-token \
+         --impersonate-service-account=<SA> \
+         --audiences=<IAP_CLIENT_ID> \
+         --include-email
+              │
+              ├─ gcloud uses the engineer's credentials to call:
+              │    IAM API → projects/-/serviceAccounts/<SA>:generateIdToken
+              │
+              └─ IAM API returns an ID token with:
+                   iss: accounts.google.com
+                   aud: <IAP_CLIENT_ID>  ← matches IAP's expected audience
+                   email: <SA>@...       ← IAP checks this against its policy
+```
+
+The `--include-email` flag is critical — without it, the token lacks the `email` claim and IAP cannot match it against its access policy.
+
+### IAM setup
+
+| Principal | Role | Resource |
+|---|---|---|
+| `group:role-deploy-user@sentry.io` | `roles/iam.serviceAccountTokenCreator` | The impersonated SA |
+| The impersonated SA | `roles/iap.httpsResourceAccessor` | GoCD IAP web resource |
+
+The `role-deploy-user@sentry.io` group is the same group that grants access to the GoCD web UI, so any engineer who can see GoCD in a browser can also use this skill.
+
+### Why service account impersonation is secure
+
+1. **No keys are distributed.** The service account has no exported key files. Engineers authenticate as themselves — their own `gcloud auth login` session is the only credential on disk. There is nothing to leak or rotate.
+
+2. **Every call is audited.** Cloud Audit Logs record which user impersonated the SA, when, and what API call they made. This is more traceable than shared API keys or tokens.
+
+3. **Access is instantly revocable.** Remove someone from `role-deploy-user@sentry.io` and they lose impersonation rights immediately. No keys to rotate, no tokens to invalidate.
+
+4. **Tokens are short-lived.** Each impersonated identity token is valid for ~1 hour and is minted fresh per invocation. There is no long-lived credential to steal.
+
+5. **Least privilege.** The SA only has `iap.httpsResourceAccessor` — it can pass through IAP, nothing else. The engineer only has `serviceAccountTokenCreator` on this one SA — they cannot impersonate other service accounts.
+
+6. **No credential sharing.** Each engineer uses their own identity. Compare this to a shared `GOCD_ACCESS_TOKEN` environment variable that gets copy-pasted between machines with no attribution.
+
+### Current configuration
+
+| Setting | Value |
+|---|---|
+| Impersonated SA | `incident-scout-bot@incident-scout-bot.iam.gserviceaccount.com` |
+| IAP audience | `610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com` |
+| GoCD host | `https://deploy.getsentry.net` |
+
+## Alternatives considered
+
+| Approach | Why not |
+|---|---|
+| `GOCD_ACCESS_TOKEN` env var | Shared secret, no audit trail, must be manually distributed |
+| `gcloud auth print-identity-token --audiences=...` (user account) | Not supported by gcloud for user accounts |
+| Browser OAuth flow + cached refresh token | Interactive on first use, refresh tokens can expire after 6 months of inactivity |
+| Service account key file | Keys can be leaked, must be rotated, Google recommends avoiding them |
+| `gcloud auth print-identity-token` (no audience) | Token audience doesn't match IAP client ID — rejected with 401 |

--- a/plugins/sentry-skills/skills/gocd-deploy-status/scripts/gocd.py
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/scripts/gocd.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -102,6 +103,49 @@ def api_get_text(session: requests.Session, path: str) -> str:
         print(json.dumps({"error": f"HTTP {resp.status_code}", "message": resp.text[:500]}, indent=2))
         sys.exit(1)
     return resp.text
+
+
+def try_get_text(session: requests.Session, path: str) -> str | None:
+    """Like api_get_text but returns None on any failure (used for best-effort log fetches)."""
+    try:
+        resp = session.get(f"{GOCD_HOST}{path}")
+        return resp.text if resp.ok else None
+    except requests.RequestException:
+        return None
+
+
+_DEDUP_DIGIT_RE = re.compile(r"\d+")
+
+
+def smart_dedup(lines: list[str], min_run: int = 4) -> tuple[list[str], dict]:
+    """Collapse runs of >=min_run consecutive lines that differ only in digit fields.
+
+    Replaces digit sequences with `#` to detect "same line, different counter/timestamp/host"
+    patterns common in deploy logs (e.g. `Pod 1/100 ready`, `[12:34:01] migrating ...`).
+    """
+    if len(lines) < min_run:
+        return lines, {"groups_collapsed": 0, "lines_saved": 0}
+
+    out: list[str] = []
+    groups = 0
+    saved = 0
+    i = 0
+    while i < len(lines):
+        norm = _DEDUP_DIGIT_RE.sub("#", lines[i])
+        j = i + 1
+        while j < len(lines) and _DEDUP_DIGIT_RE.sub("#", lines[j]) == norm:
+            j += 1
+        run = j - i
+        if run >= min_run:
+            out.append(lines[i])
+            out.append(f"... [{run - 2} similar lines collapsed] ...")
+            out.append(lines[j - 1])
+            groups += 1
+            saved += run - 3
+        else:
+            out.extend(lines[i:j])
+        i = j
+    return out, {"groups_collapsed": groups, "lines_saved": saved}
 
 
 def fmt_timestamp(ms: int | None) -> str | None:
@@ -201,9 +245,13 @@ def cmd_status(session: requests.Session, args: argparse.Namespace) -> None:
         print(json.dumps({"group": args.pipeline, "pipelines": results}, indent=2))
 
 
+GOCD_PAGE_SIZE_MIN = 10
+
+
 def cmd_history(session: requests.Session, args: argparse.Namespace) -> None:
-    data = api_get(session, f"/go/api/pipelines/{args.pipeline}/history?page_size={args.count}")
-    runs = [fmt_pipeline_run(r) for r in data.get("pipelines", [])]
+    page_size = max(GOCD_PAGE_SIZE_MIN, args.count)
+    data = api_get(session, f"/go/api/pipelines/{args.pipeline}/history?page_size={page_size}")
+    runs = [fmt_pipeline_run(r) for r in data.get("pipelines", [])][:args.count]
     print(json.dumps({"pipeline": args.pipeline, "total": len(runs), "runs": runs}, indent=2))
 
 
@@ -244,11 +292,22 @@ def cmd_job_log(session: requests.Session, args: argparse.Namespace) -> None:
         f"/{args.stage}/{args.stage_counter}"
         f"/{args.job}/cruise-output/console.log"
     )
-    lines = api_get_text(session, path).splitlines()
-    total = len(lines)
-    truncated = bool(args.tail) and total > args.tail
-    if truncated:
-        lines = lines[-args.tail:]
+    raw = api_get_text(session, path).splitlines()
+    total = len(raw)
+
+    if args.full:
+        out_lines = raw
+        dedup_summary: dict | None = None
+        truncated = False
+    else:
+        deduped, dedup_summary = smart_dedup(raw)
+        if args.tail and len(deduped) > args.tail:
+            out_lines = deduped[-args.tail:]
+            truncated = True
+        else:
+            out_lines = deduped
+            truncated = False
+
     print(json.dumps({
         "pipeline": args.pipeline,
         "pipeline_counter": args.pipeline_counter,
@@ -256,9 +315,92 @@ def cmd_job_log(session: requests.Session, args: argparse.Namespace) -> None:
         "stage_counter": args.stage_counter,
         "job": args.job,
         "total_lines": total,
-        "showing_lines": len(lines),
+        "showing_lines": len(out_lines),
         "truncated": truncated,
-        "log": "\n".join(lines),
+        "dedup": dedup_summary,
+        "log": "\n".join(out_lines),
+    }, indent=2))
+
+
+def _scan_run_for_sha(run: dict, sha_lower: str) -> tuple[str | None, str | None]:
+    """Find a (revision, material_name) pair where revision matches the given SHA."""
+    for rev in run.get("build_cause", {}).get("material_revisions", []):
+        for mod in rev.get("modifications", []):
+            revision = (mod.get("revision") or "").lower()
+            if revision and (revision.startswith(sha_lower) or sha_lower in revision):
+                return mod.get("revision"), rev.get("material", {}).get("name")
+    return None, None
+
+
+def cmd_find_deploy(session: requests.Session, args: argparse.Namespace) -> None:
+    """Search recent pipeline runs for ones that include a given commit SHA."""
+    sha_lower = args.sha.lower()
+    pipelines = resolve_pipelines(session, args.pipeline)
+    page_size = max(GOCD_PAGE_SIZE_MIN, args.count)
+    matches = []
+    for p in pipelines:
+        data = api_get(session, f"/go/api/pipelines/{p}/history?page_size={page_size}")
+        for run in data.get("pipelines", [])[:args.count]:
+            rev, mat = _scan_run_for_sha(run, sha_lower)
+            if rev is None:
+                continue
+            matches.append({
+                "pipeline": p,
+                "counter": run.get("counter"),
+                "matched_revision": rev,
+                "material": mat,
+                "scheduled": fmt_timestamp(run.get("scheduled_date")),
+                "stages": [
+                    {"name": s.get("name"), "status": s.get("result") or s.get("status")}
+                    for s in run.get("stages", [])
+                ],
+            })
+    print(json.dumps({
+        "sha": args.sha,
+        "matches": matches,
+        "searched_pipelines": pipelines,
+        "search_window": args.count,
+    }, indent=2))
+
+
+def cmd_failures(session: requests.Session, args: argparse.Namespace) -> None:
+    """Find recent failed runs in a pipeline or group, with first failed job's log tail."""
+    pipelines = resolve_pipelines(session, args.pipeline)
+    page_size = max(GOCD_PAGE_SIZE_MIN, args.count)
+    failures = []
+    for p in pipelines:
+        data = api_get(session, f"/go/api/pipelines/{p}/history?page_size={page_size}")
+        for run in data.get("pipelines", [])[:args.count]:
+            for stage in run.get("stages", []):
+                if stage.get("result") != "Failed":
+                    continue
+                failed_jobs = [
+                    j.get("name") for j in stage.get("jobs", []) if j.get("result") == "Failed"
+                ]
+                log_excerpt = None
+                if failed_jobs:
+                    log_path = (
+                        f"/go/files/{p}/{run.get('counter')}"
+                        f"/{stage.get('name')}/{stage.get('counter')}"
+                        f"/{failed_jobs[0]}/cruise-output/console.log"
+                    )
+                    raw = try_get_text(session, log_path)
+                    if raw is not None:
+                        deduped, _ = smart_dedup(raw.splitlines())
+                        log_excerpt = "\n".join(deduped[-50:])
+                failures.append({
+                    "pipeline": p,
+                    "counter": run.get("counter"),
+                    "scheduled": fmt_timestamp(run.get("scheduled_date")),
+                    "stage": stage.get("name"),
+                    "stage_counter": stage.get("counter"),
+                    "failed_jobs": failed_jobs,
+                    "log_excerpt": log_excerpt,
+                })
+    print(json.dumps({
+        "pipeline_or_group": args.pipeline,
+        "failures": failures,
+        "search_window": args.count,
     }, indent=2))
 
 
@@ -281,13 +423,23 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("stage")
     p.add_argument("stage_counter")
 
-    p = sub.add_parser("job-log", help="Console log for a job")
+    p = sub.add_parser("job-log", help="Console log for a job (smart-deduped by default)")
     p.add_argument("pipeline")
     p.add_argument("pipeline_counter")
     p.add_argument("stage")
     p.add_argument("stage_counter")
     p.add_argument("job")
-    p.add_argument("--tail", type=int, default=200)
+    p.add_argument("--tail", type=int, default=200, help="Lines after dedup to keep (default 200)")
+    p.add_argument("--full", action="store_true", help="Return entire raw log, no dedup or tail")
+
+    p = sub.add_parser("find-deploy", help="Find pipeline runs containing a commit SHA")
+    p.add_argument("sha", help="Full or partial commit SHA")
+    p.add_argument("pipeline", help="Pipeline name or group to search")
+    p.add_argument("--count", type=int, default=20, help="Runs per pipeline to scan (default 20)")
+
+    p = sub.add_parser("failures", help="Recent failed runs in a pipeline or group")
+    p.add_argument("pipeline")
+    p.add_argument("--count", type=int, default=10, help="Runs per pipeline to scan (default 10)")
 
     return parser
 
@@ -301,6 +453,8 @@ def main() -> None:
         "history": cmd_history,
         "stage": cmd_stage,
         "job-log": cmd_job_log,
+        "find-deploy": cmd_find_deploy,
+        "failures": cmd_failures,
     }[args.command](session, args)
 
 

--- a/plugins/sentry-skills/skills/gocd-deploy-status/scripts/gocd.py
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/scripts/gocd.py
@@ -1,0 +1,308 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["requests"]
+# ///
+"""
+GoCD read-only deployment API client for Sentry.
+
+Auth:
+    - IAP token: minted via service account impersonation (gcloud)
+    - GoCD token: from GOCD_ACCESS_TOKEN env var, else GCP Secret Manager
+
+Commands: pipelines, status, history, stage, job-log
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+import requests
+
+GOCD_HOST = os.environ.get("GOCD_HOST", "https://deploy.getsentry.net")
+IAP_CLIENT_ID = os.environ.get(
+    "GOCD_IAP_CLIENT_ID",
+    "610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com",
+)
+IAP_SERVICE_ACCOUNT = os.environ.get(
+    "GOCD_IAP_SERVICE_ACCOUNT",
+    "incident-scout-bot@incident-scout-bot.iam.gserviceaccount.com",
+)
+
+
+def get_iap_token() -> str | None:
+    """Mint an IAP identity token by impersonating a service account via gcloud."""
+    try:
+        result = subprocess.run(
+            [
+                "gcloud", "auth", "print-identity-token",
+                f"--impersonate-service-account={IAP_SERVICE_ACCOUNT}",
+                f"--audiences={IAP_CLIENT_ID}",
+                "--include-email",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"Warning: could not get IAP token: {e}", file=sys.stderr)
+        return None
+
+
+def get_gocd_token() -> str:
+    """Fetch GoCD API token from env var, else GCP Secret Manager."""
+    if env_token := os.environ.get("GOCD_ACCESS_TOKEN", "").strip():
+        return env_token
+    try:
+        result = subprocess.run(
+            [
+                "gcloud", "secrets", "versions", "access", "latest",
+                "--secret=gocd-access-token",
+                "--project=dicd-team-devinfra-cd",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(
+            f"Error: could not retrieve GoCD token: {e}\nSet GOCD_ACCESS_TOKEN"
+            + " to a personal token, or run `gcloud auth login` and ensure access"
+            + " to project dicd-team-devinfra-cd.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def build_session() -> requests.Session:
+    session = requests.Session()
+    session.headers["Authorization"] = f"bearer {get_gocd_token()}"
+    if iap_token := get_iap_token():
+        session.headers["Proxy-Authorization"] = f"Bearer {iap_token}"
+    return session
+
+
+def api_get(session: requests.Session, path: str, version: int = 1) -> dict:
+    """GET a GoCD API endpoint, return parsed JSON."""
+    resp = session.get(
+        f"{GOCD_HOST}{path}",
+        headers={"Accept": f"application/vnd.go.cd.v{version}+json"},
+    )
+    if not resp.ok:
+        print(json.dumps({"error": f"HTTP {resp.status_code}", "message": resp.text[:500]}, indent=2))
+        sys.exit(1)
+    return resp.json()
+
+
+def api_get_text(session: requests.Session, path: str) -> str:
+    """GET a GoCD endpoint, return raw text (for console logs)."""
+    resp = session.get(f"{GOCD_HOST}{path}")
+    if not resp.ok:
+        print(json.dumps({"error": f"HTTP {resp.status_code}", "message": resp.text[:500]}, indent=2))
+        sys.exit(1)
+    return resp.text
+
+
+def fmt_timestamp(ms: int | None) -> str | None:
+    if ms is None:
+        return None
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+
+
+def fmt_stage(stage: dict) -> dict:
+    return {
+        "name": stage.get("name"),
+        "counter": stage.get("counter"),
+        "status": stage.get("result") or stage.get("status", "Unknown"),
+        "jobs": [
+            {
+                "name": j.get("name"),
+                "state": j.get("state"),
+                "result": j.get("result"),
+                "scheduled": fmt_timestamp(j.get("scheduled_date")),
+            }
+            for j in stage.get("jobs", [])
+        ],
+    }
+
+
+def fmt_materials(build_cause: dict) -> list[dict]:
+    out = []
+    for rev in build_cause.get("material_revisions", []):
+        mat = rev.get("material", {})
+        mods = rev.get("modifications", [])
+        latest = mods[0] if mods else {}
+        out.append({
+            "name": mat.get("name"),
+            "type": mat.get("type"),
+            "revision": latest.get("revision"),
+            "user": latest.get("user_name"),
+            "comment": (latest.get("comment") or "")[:120],
+        })
+    return out
+
+
+def fmt_pipeline_run(run: dict) -> dict:
+    return {
+        "name": run.get("name"),
+        "counter": run.get("counter"),
+        "scheduled": fmt_timestamp(run.get("scheduled_date")),
+        "materials": fmt_materials(run.get("build_cause", {})),
+        "stages": [fmt_stage(s) for s in run.get("stages", [])],
+    }
+
+
+def fetch_pipeline_groups(session: requests.Session) -> dict[str, list[str]]:
+    """Map of group name -> pipeline names."""
+    data = api_get(session, "/go/api/admin/pipeline_groups")
+    return {
+        g.get("name"): [p.get("name") for p in g.get("pipelines", [])]
+        for g in data.get("_embedded", {}).get("groups", [])
+    }
+
+
+def resolve_pipelines(session: requests.Session, name: str) -> list[str]:
+    """If name is a group, return its pipelines. Otherwise return [name]."""
+    groups = fetch_pipeline_groups(session)
+    return groups[name] if name in groups else [name]
+
+
+def cmd_pipelines(session: requests.Session, args: argparse.Namespace) -> None:
+    output = [
+        {"group": name, "pipelines": pipelines}
+        for name, pipelines in fetch_pipeline_groups(session).items()
+        if pipelines
+    ]
+    print(json.dumps(output, indent=2))
+
+
+def _pipeline_status(session: requests.Session, name: str) -> dict:
+    status = api_get(session, f"/go/api/pipelines/{name}/status")
+    history = api_get(session, f"/go/api/pipelines/{name}/history?page_size=10")
+    runs = history.get("pipelines", [])
+    return {
+        "pipeline": name,
+        "paused": status.get("paused", False),
+        "paused_cause": status.get("paused_cause"),
+        "paused_by": status.get("paused_by"),
+        "locked": status.get("locked", False),
+        "schedulable": status.get("schedulable", True),
+        "latest_run": fmt_pipeline_run(runs[0]) if runs else None,
+    }
+
+
+def cmd_status(session: requests.Session, args: argparse.Namespace) -> None:
+    pipelines = resolve_pipelines(session, args.pipeline)
+    if len(pipelines) == 1:
+        print(json.dumps(_pipeline_status(session, pipelines[0]), indent=2))
+    else:
+        results = [_pipeline_status(session, p) for p in pipelines]
+        print(json.dumps({"group": args.pipeline, "pipelines": results}, indent=2))
+
+
+def cmd_history(session: requests.Session, args: argparse.Namespace) -> None:
+    data = api_get(session, f"/go/api/pipelines/{args.pipeline}/history?page_size={args.count}")
+    runs = [fmt_pipeline_run(r) for r in data.get("pipelines", [])]
+    print(json.dumps({"pipeline": args.pipeline, "total": len(runs), "runs": runs}, indent=2))
+
+
+def cmd_stage(session: requests.Session, args: argparse.Namespace) -> None:
+    data = api_get(
+        session,
+        f"/go/api/stages/{args.pipeline}/{args.pipeline_counter}/{args.stage}/{args.stage_counter}",
+        version=3,
+    )
+    jobs = []
+    for j in data.get("jobs", []):
+        transitions = {t["state"]: t.get("state_change_time") for t in j.get("job_state_transitions", [])}
+        jobs.append({
+            "name": j.get("name"),
+            "state": j.get("state"),
+            "result": j.get("result"),
+            "agent_uuid": j.get("agent_uuid"),
+            "scheduled": fmt_timestamp(j.get("scheduled_date")),
+            "assigned": transitions.get("Assigned"),
+            "preparing": transitions.get("Preparing"),
+            "building": transitions.get("Building"),
+            "completing": transitions.get("Completing"),
+            "completed": transitions.get("Completed"),
+        })
+    print(json.dumps({
+        "pipeline": data.get("pipeline_name"),
+        "pipeline_counter": data.get("pipeline_counter"),
+        "stage": data.get("name"),
+        "stage_counter": data.get("counter"),
+        "result": data.get("result"),
+        "jobs": jobs,
+    }, indent=2))
+
+
+def cmd_job_log(session: requests.Session, args: argparse.Namespace) -> None:
+    path = (
+        f"/go/files/{args.pipeline}/{args.pipeline_counter}"
+        f"/{args.stage}/{args.stage_counter}"
+        f"/{args.job}/cruise-output/console.log"
+    )
+    lines = api_get_text(session, path).splitlines()
+    total = len(lines)
+    truncated = bool(args.tail) and total > args.tail
+    if truncated:
+        lines = lines[-args.tail:]
+    print(json.dumps({
+        "pipeline": args.pipeline,
+        "pipeline_counter": args.pipeline_counter,
+        "stage": args.stage,
+        "stage_counter": args.stage_counter,
+        "job": args.job,
+        "total_lines": total,
+        "showing_lines": len(lines),
+        "truncated": truncated,
+        "log": "\n".join(lines),
+    }, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="GoCD read-only deployment API client for Sentry")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("pipelines", help="List all pipeline groups and pipelines")
+
+    p = sub.add_parser("status", help="Current status of a pipeline or group")
+    p.add_argument("pipeline")
+
+    p = sub.add_parser("history", help="Recent pipeline runs")
+    p.add_argument("pipeline")
+    p.add_argument("--count", type=int, default=5)
+
+    p = sub.add_parser("stage", help="Stage instance details")
+    p.add_argument("pipeline")
+    p.add_argument("pipeline_counter")
+    p.add_argument("stage")
+    p.add_argument("stage_counter")
+
+    p = sub.add_parser("job-log", help="Console log for a job")
+    p.add_argument("pipeline")
+    p.add_argument("pipeline_counter")
+    p.add_argument("stage")
+    p.add_argument("stage_counter")
+    p.add_argument("job")
+    p.add_argument("--tail", type=int, default=200)
+
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    session = build_session()
+    {
+        "pipelines": cmd_pipelines,
+        "status": cmd_status,
+        "history": cmd_history,
+        "stage": cmd_stage,
+        "job-log": cmd_job_log,
+    }[args.command](session, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sentry-skills/skills/gocd-deploy-status/scripts/gocd.py
+++ b/plugins/sentry-skills/skills/gocd-deploy-status/scripts/gocd.py
@@ -14,6 +14,7 @@ Commands: pipelines, status, history, stage, job-log
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import os
 import re
@@ -105,12 +106,25 @@ def api_get_text(session: requests.Session, path: str) -> str:
     return resp.text
 
 
-def try_get_text(session: requests.Session, path: str) -> str | None:
-    """Like api_get_text but returns None on any failure (used for best-effort log fetches)."""
+def try_get_text(session: requests.Session, path: str) -> tuple[str | None, int | None]:
+    """Best-effort text fetch. Returns (text, http_status). text is None on any failure;
+    http_status is None on connection errors, otherwise the response code."""
     try:
         resp = session.get(f"{GOCD_HOST}{path}")
-        return resp.text if resp.ok else None
+        return (resp.text, resp.status_code) if resp.ok else (None, resp.status_code)
     except requests.RequestException:
+        return None, None
+
+
+def try_get_json(session: requests.Session, path: str, version: int = 1) -> dict | None:
+    """Best-effort JSON fetch. Returns None on any failure."""
+    try:
+        resp = session.get(
+            f"{GOCD_HOST}{path}",
+            headers={"Accept": f"application/vnd.go.cd.v{version}+json"},
+        )
+        return resp.json() if resp.ok else None
+    except (requests.RequestException, ValueError):
         return None
 
 
@@ -363,6 +377,45 @@ def cmd_find_deploy(session: requests.Session, args: argparse.Namespace) -> None
     }, indent=2))
 
 
+def cmd_paused(session: requests.Session, args: argparse.Namespace) -> None:
+    """List currently-paused pipelines, optionally scoped to a single group."""
+    groups = fetch_pipeline_groups(session)
+    if args.group:
+        if args.group not in groups:
+            print(json.dumps({
+                "error": f"Group not found: {args.group}",
+                "hint": "Run `pipelines` to list available groups.",
+            }, indent=2))
+            sys.exit(1)
+        targets = [(args.group, p) for p in groups[args.group]]
+    else:
+        targets = [(g, p) for g, ps in groups.items() for p in ps]
+
+    def _check(item: tuple[str, str]) -> dict | None:
+        group, pipeline = item
+        status = try_get_json(session, f"/go/api/pipelines/{pipeline}/status")
+        if not status or not status.get("paused"):
+            return None
+        return {
+            "group": group,
+            "pipeline": pipeline,
+            "paused_cause": status.get("paused_cause"),
+            "paused_by": status.get("paused_by"),
+        }
+
+    paused = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as ex:
+        for result in ex.map(_check, targets):
+            if result:
+                paused.append(result)
+
+    print(json.dumps({
+        "scope": args.group or "all",
+        "checked": len(targets),
+        "paused": paused,
+    }, indent=2))
+
+
 def cmd_failures(session: requests.Session, args: argparse.Namespace) -> None:
     """Find recent failed runs in a pipeline or group, with first failed job's log tail."""
     pipelines = resolve_pipelines(session, args.pipeline)
@@ -378,16 +431,20 @@ def cmd_failures(session: requests.Session, args: argparse.Namespace) -> None:
                     j.get("name") for j in stage.get("jobs", []) if j.get("result") == "Failed"
                 ]
                 log_excerpt = None
+                log_status = "no_failed_jobs" if not failed_jobs else "fetch_failed"
                 if failed_jobs:
                     log_path = (
                         f"/go/files/{p}/{run.get('counter')}"
                         f"/{stage.get('name')}/{stage.get('counter')}"
                         f"/{failed_jobs[0]}/cruise-output/console.log"
                     )
-                    raw = try_get_text(session, log_path)
+                    raw, http_status = try_get_text(session, log_path)
                     if raw is not None:
                         deduped, _ = smart_dedup(raw.splitlines())
                         log_excerpt = "\n".join(deduped[-50:])
+                        log_status = "ok"
+                    elif http_status == 404:
+                        log_status = "archived"
                 failures.append({
                     "pipeline": p,
                     "counter": run.get("counter"),
@@ -396,6 +453,7 @@ def cmd_failures(session: requests.Session, args: argparse.Namespace) -> None:
                     "stage_counter": stage.get("counter"),
                     "failed_jobs": failed_jobs,
                     "log_excerpt": log_excerpt,
+                    "log_status": log_status,
                 })
     print(json.dumps({
         "pipeline_or_group": args.pipeline,
@@ -441,6 +499,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("pipeline")
     p.add_argument("--count", type=int, default=10, help="Runs per pipeline to scan (default 10)")
 
+    p = sub.add_parser("paused", help="List currently-paused pipelines")
+    p.add_argument("group", nargs="?", help="Optional group to scope to; default scans all")
+
     return parser
 
 
@@ -455,6 +516,7 @@ def main() -> None:
         "job-log": cmd_job_log,
         "find-deploy": cmd_find_deploy,
         "failures": cmd_failures,
+        "paused": cmd_paused,
     }[args.command](session, args)
 
 


### PR DESCRIPTION
Sentry engineers ask GoCD a few recurring questions ("did my SHA ship?", "why did the deploy fail?", "what's paused?") and today the answer means either tabbing over to deploy.getsentry.net or pasting the shared admin token around. This skill packages those queries as a CLI for anyone in `role-deploy-user@sentry.io` (the same group that gates the GoCD web UI), with no copy-paste secrets required.

Fundamentally, querying deploy state is telemetry, not pipeline control, so the skill deliberately omits `trigger`/`pause`/`unpause`/`cancel`/`run`. Mutating actions still go through the GoCD web UI for `role-deploy-operator@sentry.io`. The CLI shape is just a convenience for "why did the deploy fail" or "what's deploying right now" investigations without context-switching out of the terminal.

Eight commands, all read-only:

- `pipelines` -- list pipeline groups
- `status <name>` -- pipeline or group status with paused/locked state
- `history <pipeline> [--count N]` -- recent runs
- `stage <pipeline> <pctr> <stage> <sctr>` -- per-job state transitions
- `job-log <p> <pc> <s> <sc> <j> [--tail N] [--full]` -- console log; smart-deduped by default (collapses runs of consecutive lines that differ only in digit fields like timestamps and host indices), `--full` to bypass dedup and tail
- `find-deploy <sha> <pipeline-or-group>` -- map a commit SHA to the runs that include it; the workflow eng-pipes' "your commit shipped" Slack bot answers
- `failures <pipeline-or-group>` -- one call collapses what was previously a chained `status` -> `stage` -> `job-log` flow; returns failed stage + jobs + last 50 lines (deduped) of the first failed job's log; `log_status` field distinguishes `ok`/`archived`/`no_failed_jobs`/`fetch_failed`
- `paused [group]` -- currently-paused pipelines (parallelized; full scan of 451 pipelines completes in ~4s)

Auth defaults to the existing pattern: fetch the GoCD token from `gocd-access-token` in `dicd-team-devinfra-cd`, mint an IAP id_token via SA impersonation (currently `incident-scout-bot`, a known piece of tech debt to be cleaned up in a follow-up by giving the skill its own dedicated IaC-managed SA), and call the API. Engineers can also mint a personal read-only token from the GoCD UI and set `GOCD_ACCESS_TOKEN` to use that instead, which produces tighter per-user audit trails. The SKILL.md includes a step-by-step walkthrough for that path covering shell rc, `direnv` `.envrc`, and inline invocation.

Verified end-to-end against `getsentry-backend`: all eight commands return expected structured JSON, smart dedup catches Sentry-specific repetition patterns (`getsentry-consumer-process-segments-{1..7}-production-canary`), `find-deploy` correctly distinguishes shipped vs in-flight per region, `paused` full scan turned up 30 paused pipelines across 27 groups with real causes ("s4s is ded", "broken in devinfra-scripts", various rollback holds).