### PR TITLE
fix(pr-writer): Refresh open PRs after material changes

### DIFF
--- a/skills/pr-writer/SKILL.md
+++ b/skills/pr-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-writer
-description: ALWAYS use this skill when creating or updating pull requests — never create or edit a PR directly without it. Follows Sentry conventions for PR titles, descriptions, and issue references. Trigger on any create PR, open PR, submit PR, make PR, update PR title, update PR description, edit PR, push and create PR, prepare changes for review task, or request for a PR writer.
+description: Create and update pull requests following Sentry conventions. Use when opening a PR or refreshing an existing PR after material changes.
 ---
 
 # PR Writer
@@ -55,9 +55,73 @@ git diff BASE...HEAD
 
 Understand the scope and purpose of all changes before writing the description.
 
-### Step 3: Write or Update the PR Description
+### Step 3: Check Existing PR
+
+If the current branch already has an open PR, inspect the current title and body before rewriting either one:
+
+```bash
+gh pr view PR_NUMBER --json number,title,body,url,baseRefName,headRefName
+```
+
+Treat the current PR title and body as inputs, not source of truth. Compare them against the current diff, not the diff from when the PR was first opened.
+
+When refreshing a PR:
+- Keep the current title only if it still matches the dominant change.
+- Rewrite vague or stale titles.
+- Rewrite the body as a fresh description of the current diff, not an append-only update log.
+
+If the branch already has an open PR, refresh it after material follow-up changes even if the user did not explicitly ask for a PR edit.
+
+Refresh when follow-up commits change reviewer expectations, such as a scope change, a new implementation approach from review feedback, or new context the current title/body no longer explains. Skip trivial edits like typos or rename-only diffs.
+
+### Step 4: Write or Update the PR Title
+
+Write the title before the body, or re-evaluate it before finalizing the body.
+
+**Title format** follows commit conventions:
+- `feat(scope): Add Slack thread replies for alert notifications`
+- `fix(scope): Preserve replay segment cursor across pagination`
+- `ref(scope): Extract shared project validation helper`
+
+Prefer:
+- The dominant change, not the latest commit
+- Specific nouns and verbs
+- The narrowest accurate type and scope
+- One clear change axis a reviewer can scan in a PR list
+
+Avoid:
+- Vague words like `update`, `cleanup`, `misc`, `fix stuff`, or `address feedback`
+- Titles that describe the process instead of the change
+- Titles that no longer match the current branch after follow-up commits
+- Trailing periods
+
+Use this test on updates: if a reviewer read only the title, would they still form the right expectation about the current diff? If not, rewrite it.
+
+### Step 5: Write or Update the PR Description
 
 Use this same structure whether you are opening a new PR or updating an existing PR body. When updating, rewrite the final PR body so it still matches this structure instead of appending ad hoc notes or preserving repository template sections.
+
+Write reviewer-facing prose, not a narrated diff.
+
+The opening summary should usually:
+- Name the primary change
+- Explain the practical effect or behavior change
+- Give the why only when it is not already obvious from the change itself
+
+Prefer:
+- Concrete nouns and verbs
+- The changed behavior before implementation detail
+- Short declarative sentences
+- Details that help a reviewer understand impact, risk, or why the code is shaped this way
+
+Avoid:
+- Throat-clearing like `This PR`, `basically`, `simply`, `just`, `some`, `various`, or `in order to`
+- Empty claims like `improves things`, `cleans things up`, or `makes this better` without saying how
+- File-by-file narration
+- Repeating the diff without adding meaning
+- Long setup or project history before the actual change
+
+When a sentence only restates what the diff already makes obvious, delete it.
 
 Use this structure for PR descriptions, ignoring any repository PR templates:
 
@@ -123,7 +187,9 @@ Avoid:
 
 If the existing PR body has stale context, repo-template scaffolding, or a delta-only update note, remove or rewrite it so the final body reads as one coherent description of the current PR.
 
-### Step 4: Create the PR
+### Step 6: Create or Update the PR
+
+For a new PR, create a draft with the rewritten title and body:
 
 ```bash
 gh pr create --draft --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
@@ -132,10 +198,16 @@ EOF
 )"
 ```
 
-**Title format** follows commit conventions:
-- `feat(scope): Add new feature`
-- `fix(scope): Fix the bug`
-- `ref: Refactor something`
+For an existing PR, patch the title and body after you have re-evaluated both. If the current title still fits, keep it intentionally rather than skipping title review.
+
+```bash
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER \
+  -f title='new: Title' \
+  -f body="$(cat <<'EOF'
+<updated description body here>
+EOF
+)"
+```
 
 ## PR Description Examples
 
@@ -242,29 +314,8 @@ Reference issues in the PR body:
 - **Keep PRs reviewable** - Smaller PRs get faster, better reviews
 - **Explain the why** - Code shows what; description explains why
 - **Mark WIP early** - Use draft PRs for early feedback
-
-## Editing Existing PRs
-
-If you need to update a PR after creation, first rewrite the title and/or body using the same rules from Step 3, then use `gh api` instead of `gh pr edit`:
-
-```bash
-# Update PR description
-gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f body="$(cat <<'EOF'
-<updated description body here>
-EOF
-)"
-
-# Update PR title
-gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f title='new: Title here'
-
-# Update both
-gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER \
-  -f title='new: Title' \
-  -f body="$(cat <<'EOF'
-<updated description body here>
-EOF
-)"
-```
+- **Rewrite, don't append** - Updated PRs should read like a fresh description of the current diff
+- **Re-evaluate the title on updates** - Do not assume the existing title still fits after scope changes
 
 Note: `gh pr edit` is currently broken due to GitHub's Projects (classic) deprecation.
 

--- a/skills/pr-writer/SPEC.md
+++ b/skills/pr-writer/SPEC.md
@@ -4,15 +4,16 @@
 
 The `pr-writer` skill creates and updates pull requests with concise, review-oriented titles and descriptions that match Sentry conventions.
 
-Its main job is to turn branch changes into a readable PR body that explains what changed, why it changed, and the few details reviewers need before reading the diff. It should avoid long essays and mechanical diff summaries.
+Its main job is to turn branch changes into reviewer-facing prose that explains what changed, why it changed, and the few details reviewers need before reading the diff. It should avoid long essays, mechanical diff summaries, and vague titles that no longer match the branch scope.
 
 ## Scope
 
 In scope:
 
 - Creating draft pull requests from committed feature branches.
-- Updating existing PR titles or descriptions.
+- Updating existing PRs by re-evaluating both title and body against the current diff.
 - Producing compact PR bodies with optional bold emphasis sections.
+- Producing titles that accurately describe the dominant change in the PR.
 - Including issue references and review context when useful.
 
 Out of scope:
@@ -25,13 +26,14 @@ Out of scope:
 ## Users And Trigger Context
 
 - Primary users: engineers and coding agents preparing Sentry pull requests.
-- Common user requests: create a PR, open a PR, update a PR body, edit a PR title, prepare changes for review.
+- Common user requests: open a PR, update a PR, refresh a PR after scope changes, address review feedback after follow-up commits, prepare changes for review.
 - Should not trigger for: code review requests, commit-only requests, CI-fix loops, or generic documentation writing.
 
 ## Runtime Contract
 
-- Required first actions: verify the current branch, committed state, base branch, and diff scope before writing or updating a PR.
-- Required outputs: a conventional PR title and a concise PR body suitable for `gh pr create` or GitHub API update commands.
+- Required first actions: verify the current branch, committed state, base branch, and diff scope before writing or updating a PR; when updating, inspect the current PR title and body before deciding what to keep.
+- Required outputs: a conventional PR title and a concise PR body suitable for `gh pr create` or GitHub API update commands; on updates, include an explicit keep-or-rewrite decision for the title.
+- Required update behavior: if an open PR exists and follow-up commits materially change reviewer expectations, refresh the PR even when the user did not explicitly ask for a PR edit.
 - Non-negotiable constraints: never include customer data or PII, ignore repository PR templates, omit test-plan sections, and prefer draft PRs for newly opened pull requests.
 - Expected bundled files loaded at runtime: only `SKILL.md`.
 
@@ -48,10 +50,13 @@ Authoritative sources:
 Useful improvement sources:
 
 - positive examples: PR descriptions that reviewers can scan quickly.
+- positive examples: PR titles that stay specific after follow-up commits.
 - negative examples: PR bodies that read like essays, repeat the diff, or overuse headings.
+- negative examples: PR titles that are vague, process-oriented, or stale after scope changes.
+- negative examples: branches with material follow-up commits where the agent pushed changes but left the PR title/body stale.
 - commit logs/changelogs: only as source context, not as body text to paste.
 - issue or PR feedback: reviewer comments about missing context or excessive detail.
-- eval results: prompt-based checks for concise summaries, optional sections, and privacy boundaries.
+- eval results: prompt-based checks for title accuracy, concise summaries, optional sections, and privacy boundaries.
 
 Data that must not be stored:
 
@@ -70,15 +75,18 @@ Data that must not be stored:
 
 ## Evaluation
 
-- Lightweight validation: compare generated PR bodies against representative feature, schema-change, and refactor prompts for brevity, clarity, optional-section use, issue references, and privacy handling.
+- Lightweight validation: compare generated titles and PR bodies against representative feature, schema-change, and refactor prompts for brevity, clarity, optional-section use, issue references, update-path title handling, and privacy handling.
 - Deeper evaluation: maintain a small prompt set with expected body shapes if regressions recur.
 - Holdout examples: include at least one simple PR that should have no bold section, one PR with no known issue reference, and one API or input-format change that should use separate before/after fenced blocks.
-- Acceptance gates: output begins with a 1-3 sentence summary, uses no required generic headings, includes at most a few bold emphasis blocks, uses before/after examples only when direct comparison is the clearest explanation, omits unknown issue references instead of inventing placeholders, avoids test-plan sections, and does not include customer data.
+- Holdout examples: include at least one PR update where the old title no longer matches the final diff and must be rewritten.
+- Holdout examples: include at least one review-feedback or follow-up-commit scenario where the skill should refresh an open PR without an explicit PR-update request.
+- Acceptance gates: output title matches the dominant change, update flows explicitly re-evaluate whether the existing title still fits, material follow-up commits to an open PR trigger a refresh even without an explicit PR-update request, output begins with a 1-3 sentence summary, summary prose leads with the changed behavior before implementation detail, uses no required generic headings, includes at most a few bold emphasis blocks, uses before/after examples only when direct comparison is the clearest explanation, omits unknown issue references instead of inventing placeholders, avoids test-plan sections, and does not include customer data.
 
 ## Known Limitations
 
 - The skill cannot guarantee that issue references are correct unless the branch, commits, or user provide them, and should omit references rather than invent placeholders.
 - It relies on the agent's judgment to decide whether a bold emphasis block is useful.
+- It relies on the agent's judgment to decide when a title is still accurate enough to keep versus rewrite.
 - Very large PRs may still need more context than the default body shape encourages.
 
 ## Maintenance Notes


### PR DESCRIPTION
Refresh open PRs after material follow-up changes.

The pr-writer skill now treats an existing branch PR as something to refresh when new commits change reviewer expectations, instead of waiting for an explicit update request. It also keeps that behavior in the runtime path and leaves the YAML description tight.

**Existing PR Refresh**

The update flow now checks for an open PR on the current branch, rewrites stale title and body when scope changes, and skips trivial follow-up edits.