### PR TITLE
feat(skill-writer): Add scope-aware encapsulation depth gate

### DIFF
--- a/skills/skill-writer/SPEC.md
+++ b/skills/skill-writer/SPEC.md
@@ -57,6 +57,7 @@ Out of scope:
   - Source provenance and decisions live in `SOURCES.md`.
   - Durable positive/negative examples live in `references/evidence/`.
   - `SPEC.md` records the maintenance contract for new or materially changed skills.
+  - Globally registered skills do not bake in project-specific identifiers (file paths, hook names, domain nouns).
   - Validation runs before completion.
 - Expected bundled files loaded at runtime:
   - `references/mode-selection.md`

--- a/skills/skill-writer/references/design-principles.md
+++ b/skills/skill-writer/references/design-principles.md
@@ -67,6 +67,22 @@ Use this guide to keep skill instructions dense, scannable, and worth their toke
 - Reuse established repo-specific path variables only when the repo already standardizes on them.
 - Label provider-specific mechanics explicitly and add portability notes when they matter.
 
+## Scope-Aware Encapsulation
+
+A skill's body must not exceed its registration scope. Where the skill is registered determines what its content may reference. Distinct from `Independence And Portability`: that section governs provider portability (paths, runtime deps); this one governs body content matching registration scope.
+
+| Registration | Scope | Body may reference |
+|--------------|-------|---------------------|
+| Global (`~/.claude/skills/`, `~/.claude/agents/`) | cross-project | generic patterns, public APIs, structural placeholder names |
+| Project (`<project>/.claude/skills/`, `<project>/.claude/agents/`) | one codebase | project files, hooks, domain terms, internal helpers |
+
+A global skill that bakes in identifiers from one project ships them to every consumer of the skill, where the references resolve to nothing.
+
+- Resolve registration scope before authoring; ask the user once if ambiguous.
+- For global skills, abstract project-grounded patterns to structural placeholder names (`ExampleComponent`, `useDataHook`) before writing them into the body. Do not substitute one domain for another.
+- Source synthesis may consult a project's files for the canonical pattern; the resulting body must not.
+- Project skills may anchor freely on real codebase symbols; that's the value.
+
 ## Long Files
 
 - Keep `SKILL.md` short enough to scan as a router.

--- a/skills/skill-writer/references/mode-selection.md
+++ b/skills/skill-writer/references/mode-selection.md
@@ -65,3 +65,4 @@ Missing selected-profile requirements is also a hard failure.
 Missing required class dimensions is a hard failure.
 Missing an explicit execution-shape choice for a material skill change is a hard failure.
 Using advanced mechanics without justification or portability notes is a hard failure.
+Hard-coding project-specific identifiers in a globally registered skill is a hard failure; see `references/design-principles.md` Scope-Aware Encapsulation.


### PR DESCRIPTION
Add a Scope-Aware Encapsulation principle to `skill-writer/references/design-principles.md`, a matching hard-stop rule in `mode-selection.md`, and a sister-update to `skill-writer/SPEC.md`, so authored skills stay matched to the level at which they are registered.

**Why.** `skill-writer`'s synthesis path explicitly permits local project files as grounding evidence. For a project-scoped skill, surfacing those files' identifiers in the authored body is correct; for a globally registered skill, it is not. The rule is implicit in good practice but is not currently codified anywhere `skill-writer` consults: `Independence And Portability` covers provider portability (paths, runtime deps), and `mode-selection.md`'s portability note in synthesis outputs covers provider-specific *mechanics*, not registration-scope encapsulation of body *content*. An authoring agent following the documented synthesis-then-author flow can therefore land a global skill whose worked examples reference symbols that exist in only one project, producing references that resolve to nothing for every other consumer of the skill. This PR adds the principle, the matching hard-stop, and the contract bullet.

**Scope of the principle.** The rule targets *body content vs. registration scope*: a skill's worked examples and inline references must not exceed the scope at which it is registered. Source synthesis may consult a project's files to learn the canonical pattern; the resulting body must abstract that pattern with structural placeholder names. Project-scoped skills are explicitly carved out and may anchor freely on real codebase symbols.

**What changed.**
- `skills/skill-writer/references/design-principles.md`: add a `Scope-Aware Encapsulation` section after `Independence And Portability` with a registration/scope/body-may-reference table, an explicit one-sentence distinction from the prior section, and four bullets covering the resolution rule, the abstraction rule for globals, the consult-but-don't-bake rule for synthesis, and the carve-out for project skills.
- `skills/skill-writer/references/mode-selection.md`: add one line to `Hard stop rules` flagging hard-coded project-specific identifiers in a globally registered skill as a hard failure. Cross-references the new section.
- `skills/skill-writer/SPEC.md`: add one bullet to `Non-negotiable constraints` mirroring the new principle, so the skill's maintenance contract reflects the new gate.