### PR TITLE
docs(skills): Improve agent guidance skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Works with Claude Code, Cursor, Cline, GitHub Copilot, and other compatible agen
 
 | Skill | Description |
 |-------|-------------|
-| [agents-md](skills/agents-md/SKILL.md) | This skill should be used when the user asks to "create AGENTS.md", "update AGENTS.md", "maintain agent docs", "set up CLAUDE.md", or needs to keep agent instructions concise. |
+| [agents-md](skills/agents-md/SKILL.md) | Create and maintain concise, reference-backed AGENTS.md and CLAUDE.md files. |
 | [blog-writing-guide](skills/blog-writing-guide/SKILL.md) | Write, review, and improve blog posts for the Sentry engineering blog following Sentry's specific writing standards, voice, and quality bar. |
 | [brand-guidelines](skills/brand-guidelines/SKILL.md) | Write copy following Sentry brand guidelines. |
 | [claude-settings-audit](skills/claude-settings-audit/SKILL.md) | Analyze a repository to generate recommended Claude Code settings.json permissions. |
@@ -58,7 +58,7 @@ Works with Claude Code, Cursor, Cline, GitHub Copilot, and other compatible agen
 | [iterate-pr](skills/iterate-pr/SKILL.md) | Iterate on a PR until CI passes. |
 | [presentation-creator](skills/presentation-creator/SKILL.md) | Create data-driven presentation slides using React, Vite, and Recharts with Sentry branding. |
 | [pr-writer](skills/pr-writer/SKILL.md) | Canonical workflow to create and update pull requests following Sentry conventions. |
-| [prompt-optimizer](skills/prompt-optimizer/SKILL.md) | Create, optimize, and iteratively refine agent prompts and system prompts. |
+| [prompt-optimizer](skills/prompt-optimizer/SKILL.md) | Optimize prompts with evals, model-family adapters, and exact external context references. |
 | [replay-ux-research](skills/replay-ux-research/SKILL.md) | Analyze Sentry session replays to surface UX patterns, pain points, and user journeys for a given product area. |
 | [security-review](skills/security-review/SKILL.md) | Security code review for vulnerabilities. |
 | [skill-scanner](skills/skill-scanner/SKILL.md) | Scan agent skills for security issues. |

--- a/skills/agents-md/SKILL.md
+++ b/skills/agents-md/SKILL.md
@@ -1,118 +1,95 @@
 ---
 name: agents-md
-description: This skill should be used when the user asks to "create AGENTS.md", "update AGENTS.md", "maintain agent docs", "set up CLAUDE.md", or needs to keep agent instructions concise. Enforces research-backed best practices for minimal, high-signal agent documentation.
+description: Creates and maintains concise AGENTS.md and CLAUDE.md project instruction files. Use when asked to create AGENTS.md, update AGENTS.md, maintain agent docs, set up CLAUDE.md, document repository agent conventions, or keep coding-agent instructions minimal and reference-backed.
 ---
 
 # Maintaining AGENTS.md
 
-AGENTS.md is the canonical agent-facing documentation. Keep it minimal—agents are capable and don't need hand-holding. Target under 60 lines; never exceed 100. Instruction-following quality degrades as document length increases.
+Goal: concise, actionable agent instructions. Target under 60 lines; never exceed 100.
+
+## Workflow
+
+1. Inspect before writing:
+   - package manager: lock files and manifests
+   - commands: `package.json`, `Makefile`, task runners, CI workflows
+   - docs/specs/policies: `README.md`, `CONTRIBUTING.md`, `docs/`, `specs/`, `policies/`, `SECURITY.md`, `.github/`
+   - conventions: current code patterns, test layout, generated files, legacy areas to avoid
+2. Choose scope:
+   - root `AGENTS.md`: repo-wide defaults
+   - nested `AGENTS.md`: only when a subtree has different commands or rules
+   - closest instruction file wins; keep narrower files shorter than root files
+3. Write the smallest useful file.
+4. Verify exact paths and commands exist.
 
 ## File Setup
 
-1. Create `AGENTS.md` at project root
-2. Create symlink: `ln -s AGENTS.md CLAUDE.md`
+- Create `AGENTS.md` at the repository root.
+- If a Claude-compatible entrypoint is required, symlink `CLAUDE.md` to `AGENTS.md`.
+- Do not maintain divergent `AGENTS.md` and `CLAUDE.md` copies.
 
-## Before Writing
+## Default Sections
 
-Analyze the project to understand what belongs in the file:
+Use only sections that add non-obvious value.
 
-1. **Package manager** — Check for lock files (`pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `uv.lock`, `poetry.lock`)
-2. **Linter/formatter configs** — Look for `.eslintrc`, `biome.json`, `ruff.toml`, `.prettierrc`, etc. (don't duplicate these in AGENTS.md)
-3. **CI/build commands** — Check `Makefile`, `package.json` scripts, CI configs for canonical commands
-4. **Monorepo indicators** — Check for `pnpm-workspace.yaml`, `nx.json`, Cargo workspace, or subdirectory `package.json` files
-5. **Existing conventions** — Check for existing CONTRIBUTING.md, docs/, or README patterns
-
-## Writing Rules
-
-- **Headers + bullets** — No paragraphs
-- **Code blocks** — For commands and templates
-- **Reference, don't embed** — Point to existing docs: "See `CONTRIBUTING.md` for setup" or "Follow patterns in `src/api/routes/`"
-- **No filler** — No intros, conclusions, or pleasantries
-- **Trust capabilities** — Omit obvious context
-- **Prefer file-scoped commands** — Per-file test/lint/typecheck commands over project-wide builds
-- **Don't duplicate linters** — Code style lives in linter configs, not AGENTS.md
-
-## Required Sections
-
-### Package Manager
-Which tool and key commands only:
-```markdown
-## Package Manager
-Use **pnpm**: `pnpm install`, `pnpm dev`, `pnpm test`
-```
-
-### File-Scoped Commands
-Per-file commands are faster and cheaper than full project builds. Always include when available:
-```markdown
-## File-Scoped Commands
-| Task | Command |
-|------|---------|
-| Typecheck | `pnpm tsc --noEmit path/to/file.ts` |
-| Lint | `pnpm eslint path/to/file.ts` |
-| Test | `pnpm jest path/to/file.test.ts` |
-```
-
-### Commit Attribution
-Always include this section. Agents should use their own identity:
-```markdown
-## Commit Attribution
-AI commits MUST include:
-```
-Co-Authored-By: (the agent's name and attribution byline)
-```
-Example: `Co-Authored-By: Claude Sonnet 4 <noreply@example.com>`
-```
-
-### Key Conventions
-Project-specific patterns agents must follow. Keep brief.
-
-## Optional Sections
-
-Add only if truly needed:
-- API route patterns (show template, not explanation)
-- CLI commands (table format)
-- File naming conventions
-- Project structure hints (point to critical files, flag legacy code to avoid)
-- Monorepo overrides (subdirectory `AGENTS.md` files override root)
-
-## Anti-Patterns
-
-Omit these:
-- "Welcome to..." or "This document explains..."
-- "You should..." or "Remember to..."
-- Linter/formatter rules already in config files (`.eslintrc`, `biome.json`, `ruff.toml`)
-- Listing installed skills or plugins (agents discover these automatically)
-- Full project-wide build commands when file-scoped alternatives exist
-- Obvious instructions ("run tests", "write clean code")
-- Explanations of why (just say what)
-- Long prose paragraphs
-
-## Example Structure
-
-```markdown
+````markdown
 # Agent Instructions
 
 ## Package Manager
-Use **pnpm**: `pnpm install`, `pnpm dev`
+- Use **pnpm**: `pnpm install`
+
+## Commands
+| Task | Command |
+|------|---------|
+| Test file | `pnpm vitest run path/to/file.test.ts` |
+| Lint file | `pnpm eslint path/to/file.ts` |
+
+## External References
+| Need | File |
+|------|------|
+| Setup | `CONTRIBUTING.md` |
+| Architecture | `docs/architecture.md` |
+| Security policy | `SECURITY.md` |
+
+## Key Conventions
+- Generated files: update with `pnpm generate`; do not edit by hand.
 
 ## Commit Attribution
 AI commits MUST include:
 ```
 Co-Authored-By: (the agent's name and attribution byline)
 ```
+````
 
-## File-Scoped Commands
-| Task | Command |
-|------|---------|
-| Typecheck | `pnpm tsc --noEmit path/to/file.ts` |
-| Lint | `pnpm eslint path/to/file.ts` |
-| Test | `pnpm jest path/to/file.test.ts` |
+## Writing Rules
 
-## API Routes
-[Template code block]
+- Use headings, bullets, and tables; avoid paragraphs.
+- Use repo-relative paths; avoid vague references like "see docs".
+- Reference existing docs/specs/policies instead of copying them.
+- List exact external files for setup, architecture, API specs, security, release, and policy docs when they exist.
+- Prefer file-scoped test/lint/typecheck commands; include full builds only when no narrower command exists.
+- Put commands in tables when there is more than one.
+- Keep one rule per bullet.
+- Keep rationale out unless it prevents a likely mistake.
+- Do not restate linter, formatter, or typechecker config.
+- Do not list installed skills or plugins.
+- Do not include generic quality slogans.
 
-## CLI
-| Command | Description |
-|---------|-------------|
-| `pnpm cli sync` | Sync data |
+## External Reference Rules
+
+Good:
+
+```markdown
+## External References
+| Need | File |
+|------|------|
+| API contract | `docs/api.md` |
+| Release process | `docs/releasing.md` |
 ```
+
+## Anti-Patterns
+
+- welcome text, intros, conclusions, or pleasantries
+- long prose explaining why instructions matter
+- duplicated content from `README.md`, `CONTRIBUTING.md`, or policy docs
+- project-wide commands when file-scoped commands are available
+- nested `AGENTS.md` files that repeat root instructions

--- a/skills/agents-md/SOURCES.md
+++ b/skills/agents-md/SOURCES.md
@@ -1,0 +1,68 @@
+# Sources
+
+This file tracks material synthesized into `agents-md`.
+
+## Selected profile
+
+- `skills/skill-writer/references/examples/workflow-process-skill.md`
+
+Why: this skill is a repeatable authoring workflow with pre-inspection, scoped output, validation, and failure controls.
+
+## Current source inventory
+
+| Source | Type | Trust tier | Retrieved | Confidence | Contribution | Usage constraints | Notes |
+|---|---|---|---|---|---|---|---|
+| `AGENTS.md` | repo policy | canonical | 2026-05-04 | high | Requires `skill-writer`, concise prose, exact registration expectations | local repository authority | Highest-priority local instruction source |
+| `README.md` | repo policy | canonical | 2026-05-04 | high | Skill layout, `SPEC.md` convention, public inventory style | local repository authority | Confirms canonical `skills/` tree |
+| `CONTRIBUTING.md` | repo policy | canonical | 2026-05-04 | high | Local testing and contribution workflow | local repository authority | Used for validation expectations |
+| `skills/skill-writer/SKILL.md` and references | local canonical | canonical | 2026-05-04 | high | Skill update workflow, source capture, authoring, validation | local repository authority | Primary authoring workflow |
+| `https://agents.md/` | official format guide | canonical | 2026-05-04 | high | AGENTS.md purpose, common sections, nested files, closest-file precedence | public format guidance | Supports path-backed and scoped instructions |
+| `https://developers.openai.com/codex/guides/agents-md` | official product docs | canonical | 2026-05-04 | high | Codex discovery order, global/project scopes, nested precedence, size cap, verification commands | OpenAI-specific behavior | Used only for compatibility guidance |
+| `https://agentskills.io/specification` | official spec | canonical | 2026-05-04 | high | Skill frontmatter, progressive disclosure, focused references | skill format guidance | Supports concise runtime file shape |
+
+## Decisions
+
+1. Make external file enumeration a default AGENTS.md section when docs/specs/policies exist.
+   Status: adopted
+   Why: AGENTS.md should point agents to exact source files instead of copying policy or asking them to scan vague directories.
+
+2. Prefer concise root files plus nested overrides.
+   Status: adopted
+   Why: official AGENTS.md and Codex docs both describe hierarchical instructions where narrower files override broader guidance.
+
+3. Keep `CLAUDE.md` as a compatibility symlink when needed.
+   Status: adopted
+   Why: one canonical instruction file avoids divergent provider-specific copies.
+
+4. Treat OpenAI `AGENTS.override.md` behavior as compatibility guidance, not a shared-repo default.
+   Status: adopted
+   Why: it is useful for Codex-specific overrides but can surprise other tools and humans if used as the main repo contract.
+
+5. Cut prose and examples to a compact template.
+   Status: adopted
+   Why: instruction-following and truncation risks grow with long agent docs; the user explicitly requested minimal prose.
+
+## Coverage matrix
+
+| Dimension | Coverage status | Evidence |
+|---|---|---|
+| Repo inspection before writing | complete | local repo policy, `skill-writer` workflow |
+| External docs/specs/policies enumeration | complete | user concern, AGENTS.md format guidance |
+| Nested scope and precedence | complete | official AGENTS.md guide, OpenAI Codex docs |
+| Prose minimization | complete | user concern, Agent Skills progressive disclosure |
+| Command precision | complete | AGENTS.md examples, repo contribution conventions |
+| CLAUDE.md compatibility | complete | existing skill behavior, local repo convention |
+| Provider-specific variance | partial | OpenAI Codex docs covered; other tools deferred until a concrete repo need |
+
+## Open gaps
+
+1. Add provider-specific discovery notes only when a concrete repository or tool requires them.
+2. Add durable before/after examples only if future changes regress into long prose or vague references.
+
+## Stopping rationale
+
+Further retrieval is currently low-yield. The source pack covers local repo policy, the official AGENTS.md format guide, OpenAI Codex discovery behavior, and the Agent Skills specification.
+
+## Changelog
+
+- 2026-05-04: Added source-backed external reference guidance, nested-scope rules, `SPEC.md`, and provenance.

--- a/skills/agents-md/SPEC.md
+++ b/skills/agents-md/SPEC.md
@@ -1,0 +1,85 @@
+# AGENTS.md Specification
+
+## Intent
+
+`agents-md` creates and maintains compact repository instruction files for coding agents.
+
+It should turn scattered repo norms into a short `AGENTS.md` index: commands, non-obvious conventions, and exact links to existing docs/specs/policies.
+
+## Scope
+
+In scope:
+
+- Root `AGENTS.md` files.
+- Nested `AGENTS.md` files for subtree-specific overrides.
+- `CLAUDE.md` compatibility symlinks when needed.
+- Concise command tables, external reference tables, and commit attribution rules.
+- Removing duplicated prose from existing agent docs.
+
+Out of scope:
+
+- Rewriting the referenced docs themselves.
+- Replacing `README.md`, `CONTRIBUTING.md`, policy docs, or architecture docs.
+- Listing installed skills/plugins.
+- Encoding linter or formatter rules already enforced by config.
+- Maintaining divergent tool-specific copies of the same instructions.
+
+## Users And Trigger Context
+
+- Primary users: engineers and agents maintaining repository-level agent instructions.
+- Should trigger for: create AGENTS.md, update AGENTS.md, maintain agent docs, set up CLAUDE.md, document repo agent conventions, reduce agent instruction prose.
+- Should not trigger for: general docs writing, PR descriptions, code review, or creating reusable agent skills.
+
+## Runtime Contract
+
+- Inspect repo commands, configs, docs, specs, and policies before writing.
+- Prefer exact repo-relative paths and command tables.
+- Enumerate external files for setup, architecture, API specs, security, release, and policy docs when present.
+- Keep root guidance broad and nested guidance narrow.
+- Keep `AGENTS.md` under 60 lines when practical and under 100 lines always.
+- Preserve the commit attribution section when the repo requires AI co-authorship.
+- Use a `CLAUDE.md` symlink only for compatibility; avoid divergent copies.
+
+## Source And Evidence Model
+
+Authoritative sources:
+
+- Repository instructions, especially root `AGENTS.md`.
+- `README.md`, `CONTRIBUTING.md`, package manifests, CI workflows, and settings files.
+- Existing project docs, specs, security docs, and policy files.
+- Official AGENTS.md format guidance and OpenAI Codex discovery behavior.
+
+Useful improvement sources:
+
+- Repositories with concise, path-backed agent docs.
+- Review feedback about stale commands, duplicated docs, or overlong instructions.
+- Agent failures caused by missing exact file paths, command ambiguity, or nested instruction conflicts.
+
+Do not store secrets, private customer data, or long copied policy text in examples.
+
+## Reference Architecture
+
+- `SKILL.md` contains the runtime checklist, template, and anti-patterns.
+- `SPEC.md` contains this maintenance contract.
+- `SOURCES.md` stores provenance, decisions, coverage, and gaps.
+- `references/`, `scripts/`, and `assets/` are unused until repeated failures require focused lookup material.
+
+## Evaluation
+
+- Lightweight validation: check the generated file for line count, exact commands, exact external paths, no duplicated policy prose, and no vague "see docs" references.
+- Trigger QA: verify create/update/CLAUDE.md requests trigger this skill, while generic docs and skill-authoring tasks do not.
+- Holdout examples: one simple single-package repo, one monorepo with nested overrides, one repo with existing docs/specs/policies to enumerate.
+- Acceptance gates: the resulting `AGENTS.md` is short, command-backed, path-backed, and free of redundant style rules.
+
+## Known Limitations
+
+- The skill relies on local file inspection; it cannot know private policy docs that are not present or supplied.
+- Some agent tools have provider-specific discovery behavior; keep compatibility notes concise and avoid making one provider the default.
+- Very large monorepos may need several nested files instead of a longer root file.
+
+## Maintenance Notes
+
+- Update `SKILL.md` when runtime sections, templates, or anti-patterns change.
+- Update `SPEC.md` when scope, evaluation, or evidence policy changes.
+- Update `SOURCES.md` when AGENTS.md discovery behavior or source-backed decisions change.
+- Add focused references only when repeated failures cannot be fixed with the compact runtime checklist.

--- a/skills/prompt-optimizer/SKILL.md
+++ b/skills/prompt-optimizer/SKILL.md
@@ -1,166 +1,122 @@
 ---
 name: prompt-optimizer
-description: Create, optimize, and iteratively refine agent prompts and system prompts. Use when asked to "improve a prompt", "optimize a system prompt", "rewrite an agent prompt", "tune prompt wording", "make this prompt more reliable", or "adapt a prompt for OpenAI, Claude, or Gemini". Handles model-specific prompt guidance, prompt markers/tags, eval design, and meta optimization loops for new and existing prompts.
+description: Creates, optimizes, and iteratively refines agent prompts, system prompts, developer prompts, and reusable prompt templates. Use when asked to improve a prompt, optimize a system prompt, rewrite an agent prompt, tune prompt wording, make a prompt more reliable, port prompts between OpenAI, Claude, or Gemini, or build prompt evals.
 ---
 
 # Prompt Optimizer
 
-Optimize prompts for agents, system/developer instructions, and reusable prompt templates.
-Treat prompt work as an eval-driven workflow, not wordsmithing.
+Optimize prompts with evals. Keep every instruction, example, and external context reference causal.
 
-Load only the references you need:
+## Load Only What You Need
 
-| Task | Read |
+| Need | Read |
 |------|------|
-| Create a new agent prompt | `references/core-patterns.md`, `references/model-family-notes.md`, `references/transformed-examples.md` |
-| Refine an existing prompt | `references/meta-optimization-loop.md`, `references/core-patterns.md`, `references/model-family-notes.md`, `references/transformed-examples.md` |
-| Port a prompt between model families | `references/model-family-notes.md`, `references/core-patterns.md` |
-| Diagnose repeated prompt failures | `references/meta-optimization-loop.md`, `references/core-patterns.md` |
-| Explain the provenance behind this workflow | `SOURCES.md` |
+| New prompt | `references/core-patterns.md`, `references/model-family-notes.md`, `references/transformed-examples.md` |
+| Existing prompt | `references/meta-optimization-loop.md`, `references/core-patterns.md`, `references/model-family-notes.md` |
+| Model-family port | `references/model-family-notes.md`, `references/core-patterns.md` |
+| Repeated failures | `references/meta-optimization-loop.md`, `references/core-patterns.md` |
+| Weak or ambiguous draft | `references/transformed-examples.md` |
+| Provenance | `SOURCES.md` |
 
-## Step 1: Define the prompt contract
+## Step 1: Capture Contract
 
-1. Determine whether the task is:
-- creating a new prompt
-- refining an existing prompt
-- porting a prompt between model families
-- debugging prompt failures
+Record before editing:
 
-2. Capture the contract before rewriting anything:
-- target model family and snapshot if known
+- task type: new, refine, port, or debug
+- target model family and snapshot, if known
 - prompt surface: `system`, `developer`, `user`, tool descriptions, examples, schemas
-- task objective and non-goals
-- inputs, context, and tools available to the agent
+- layer owners: platform, deployer/persona, retrieved context, user payload
+- objective and non-goals
+- inputs, tools, and external files available
 - required output shape
-- success criteria
-- known failures
+- success criteria and failure cases
 - hard constraints: latency, verbosity, safety, budget, tool use, style
 
-3. If the user does not provide success criteria or examples, build a small eval set before editing the prompt.
+If success criteria or examples are missing, create a small eval set first.
+If the bottleneck is model choice, retrieval, tool schema, or missing evals, say so before rewriting.
 
-4. If the real bottleneck is model choice, missing retrieval, weak tool schemas, or a missing eval harness, say so. Do not keep rewriting prompt text when the failure is elsewhere.
+## Step 2: Inventory External Context
 
-## Step 2: Choose the model strategy
+For repo or agent prompts, list stable context by exact path:
+
+| Context type | Examples |
+|--------------|----------|
+| Agent rules | `AGENTS.md`, `CLAUDE.md` |
+| Specs | `specs/*.md`, `docs/api.md` |
+| Policies | `SECURITY.md`, `docs/releasing.md` |
+| Examples | `examples/`, `tests/fixtures/` |
+
+Rules:
+
+- Reference stable files by repo-relative path instead of copying them.
+- Paste only excerpts needed for the prompt or eval case.
+- Mark whether a file is `loaded`, `referenced`, or `out of scope`.
+- Avoid vague context pointers such as "read the docs".
+
+## Step 3: Choose Model Strategy
 
 Read `references/model-family-notes.md`.
 
-1. If the target family is known, optimize specifically for that family.
-2. If the target family is unknown, write:
-- a portable base prompt
-- short adapter notes for the likely target families
-3. Do not pretend one prompt is universal when the behavior clearly depends on model family.
-4. Pin model snapshots when the surrounding system supports it.
+- Known family: optimize for that family.
+- Unknown family: write a portable base plus short adapter notes.
+- Snapshot changes: rerun evals.
+- Cross-family divergence: specialize only the failing layer.
 
-## Step 3: Shape the prompt deliberately
+## Step 4: Shape Prompt
 
 Read `references/core-patterns.md`.
 
-1. Separate durable behavior from task-local context:
-- stable policy and behavioral defaults belong in `system` or `developer`
-- variable inputs, retrieved context, and task instances belong in templated user-facing sections
-- when the system prompt is assembled at runtime from a platform layer and a deployer-authored persona layer (e.g., `SOUL.md`, `CLAUDE.md`, `AGENTS.md`), see "Layered prompts with multiple owners" in `references/core-patterns.md` — platform behavior rules must not depend on what the deployer layer contains
+- Put stable policy in `system` or `developer`.
+- Put task-local facts, retrieved context, and variables in user-facing sections.
+- Keep one owner per behavior rule.
+- Use headings or tags only to separate content types.
+- Put tool policy in prompt text; keep schemas in provider-native tools.
+- Keep persona light unless it changes behavior.
+- Use the shortest wording that preserves the constraint.
+- Cut filler, repeated reminders, dead examples, and rationale that does not affect evals.
 
-2. Keep one authoritative instruction per behavior:
-- if a rule appears in more than one layer, choose one owner for it
-- stable cross-task rules belong in `system` or `developer`
-- examples should teach format, edge-case handling, or tool behavior, not restate the whole policy
-- user payloads should carry task-local facts, not durable policy
+## Step 5: Optimize
 
-3. Use markers only when they reduce ambiguity:
-- use markdown headings or XML-style tags to separate instructions, context, examples, tool rules, and output contracts
-- keep tag names descriptive and consistent
-- do not wrap every sentence in markup
+Read `references/meta-optimization-loop.md` for refinements.
 
-4. Make the prompt easy to execute:
-- put one high-value behavior per bullet or line when the task is fragile
-- prefer positive instructions over "do not do X" lists
-- place tool-use rules, escalation boundaries, and stop conditions in explicit sections
-- keep persona light unless it changes behavior in a useful way
-- use the shortest wording that preserves the intended behavioral constraint
-- cut motivational filler, repeated reminders, and examples that do not improve evals
-- for long-context prompts, place evidence before the final query and keep the actual ask in a clear terminal section
-- keep instructions, evidence, and schemas in distinct blocks so the model does not have to infer what is policy versus data
+1. Baseline the current prompt on the same eval slice.
+2. Cluster failures by root cause.
+3. Write concrete edit criticisms.
+4. Generate two to four candidates:
+   - minimal-diff repair
+   - structure-first rewrite
+   - examples-first or tool-rule variant
+   - provider adapter when needed
+5. Compare candidates on the same cases.
+6. Keep a short optimization log.
+7. Validate the winner on holdout cases.
+8. Stop on plateau, oscillation, overfit, excessive cost, or non-prompt bottleneck.
 
-5. Treat examples as first-class prompt assets:
-- start simple before adding examples
-- add examples only when they improve format control, edge-case handling, or tool behavior
-- keep examples structurally consistent
-- prefer positive demonstrations over anti-pattern-only demonstrations
-
-## Step 4: Run the meta optimization loop
-
-Read `references/meta-optimization-loop.md`.
-
-1. Start with the current prompt or a simple first draft.
-2. Score it on a representative slice:
-- at least one happy-path case
-- at least one failure replay
-- at least one ambiguous case
-- at least one edge case
-- at least one "should refuse", "should ask", or "should defer" case when relevant
-
-3. Turn failures into explicit criticisms:
-- identify what the prompt under-specified, over-specified, or contradicted
-- write critiques as actionable edits, not vague complaints
-
-4. Generate a small beam of candidate prompts:
-- one minimal-diff repair
-- one structure-first rewrite
-- one example- or tool-rule-centered variant when that is the likely bottleneck
-- one provider-specific adapter when cross-model behavior is the issue
-
-5. Compare candidates on the same eval slice.
-6. Keep the best candidate and log what changed and why.
-7. Preserve the evidence for each round:
-- prompt version
-- eval case
-- model output
-- failure reason
-- relevant scores
-
-8. Test the winner on a holdout slice before finalizing.
-9. Stop when scores plateau, edits oscillate, cost rises without quality gain, or the remaining issue is outside prompt control.
-
-Keep edits minimal and causal. Record what you removed as well as what you added. If you change everything at once, you learn nothing about what actually helped.
-
-## Step 5: Produce a reusable deliverable
+## Step 6: Return Package
 
 Return:
 
 1. `Target`
 2. `Success Criteria`
-3. `Optimized Prompt`
-4. `Adapter Notes`
-5. `Eval Set`
-6. `Optimization Log`
-7. `Residual Risks`
+3. `External Context`
+4. `Optimized Prompt`
+5. `Adapter Notes`
+6. `Eval Set`
+7. `Optimization Log`
+8. `Residual Risks`
 
-If the user supplied an existing prompt, include a concise diff-style explanation of the biggest behavioral changes.
+For existing prompts, include a concise diff-style note of the main behavioral changes.
 
-## Step 6: Guard against common failure modes
+## Failure Modes
 
-Read `references/transformed-examples.md` when the task is ambiguous or the first draft is weak.
-
-Do not:
-
-- optimize wording before defining the eval target
-- mix instructions, examples, and raw context without boundaries
-- keep the same rule in multiple layers unless there is a proven reason
-- let stable rules drift into the user payload just because the current prompt template makes it convenient
-- ask reasoning models to reveal chain-of-thought just because the task is hard
-- keep contradictory legacy instructions in the same prompt
-- overfit to one or two examples
-- keep examples that do not improve measured behavior
-- solve tool-use failures only in the system prompt when the real problem is the tool description or schema
-- add markers everywhere and mistake structure for clarity
-- use a bloated persona as a substitute for concrete behavior rules
-
-## Output standard
-
-The final prompt package should be reusable by another engineer without rediscovering:
-
-- what the prompt is for
-- which model family it targets
-- how success is measured
-- what changed during optimization
-- which risks remain open
+- editing before defining the eval target
+- mixing policy, examples, and raw context without boundaries
+- duplicating rules across layers
+- putting durable policy in user payloads
+- asking for chain-of-thought
+- keeping contradictory legacy instructions
+- overfitting to one or two examples
+- retaining examples that no longer improve evals
+- fixing tool-use failures only in prompt text when tool descriptions or schemas are weak
+- adding markup that does not reduce ambiguity
+- using persona as a substitute for behavior rules

--- a/skills/prompt-optimizer/SOURCES.md
+++ b/skills/prompt-optimizer/SOURCES.md
@@ -17,9 +17,11 @@ Why: this skill is a repeatable prompt-optimization workflow with explicit preco
 | `README.md` | repo convention | canonical | 2026-04-18 | high | Skill template, naming, registration conventions | repository-local policy | Canonical public skill inventory |
 | `CONTRIBUTING.md` | repo convention | canonical | 2026-04-18 | high | Local testing and registration checklist | repository-local policy | Confirms registration steps |
 | `AGENTS.md` | repo convention | canonical | 2026-04-18 | high | Mandatory use of `skill-writer`, registration checklist, portability conventions | repository-local policy | Highest-priority local instruction source |
+| `https://agents.md/` | official format guide | canonical | 2026-05-04 | high | AGENTS.md purpose, common sections, nested files, closest-file precedence | public format guidance | Supports exact external file references in repo agent prompts |
+| `https://developers.openai.com/codex/guides/agents-md` | official product docs | canonical | 2026-05-04 | high | Codex AGENTS.md discovery, scope, merge order, size cap, verification | OpenAI-specific behavior | Used for agent prompt and repo instruction layering guidance |
+| `https://platform.openai.com/docs/guides/prompt-optimizer/` | official docs | canonical | 2026-05-04 | high | Dataset-backed prompt optimization, annotations, graders, manual review | verify product surface before dashboard-specific instructions | Confirms eval-first and manual-review loop |
+| `https://platform.openai.com/docs/guides/prompting` | official docs | canonical | 2026-05-04 | high | Prompt objects, versioning, variables, linked evals, prompt roles | product-specific features may evolve | Supports reusable prompt packages and eval reruns |
 | `https://developers.openai.com/api/docs/guides/reasoning-best-practices` | official docs | canonical | 2026-04-18 | high | Reasoning-model prompting differences, simplicity, delimiters, no explicit CoT | verify product syntax if exact API behavior matters | Used for OpenAI family notes |
-| `https://developers.openai.com/api/docs/guides/prompt-optimizer` | official docs | canonical | 2026-04-18 | high | Evals, graders, annotations, critique-driven prompt iteration | verify current product surface if depending on dashboard workflow | Supports eval-first workflow |
-| `https://developers.openai.com/api/docs/guides/prompting` | official docs | canonical | 2026-04-18 | high | Prompt versioning, reuse, prompt objects, eval linkage | product-specific features may evolve | Supports reusable prompt packaging |
 | `https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/overview` | official docs | canonical | 2026-04-18 | high | Success-criteria-first prompting and reminder that not every failure is a prompt problem | product syntax may evolve | Supports precondition checks |
 | `https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices` | official docs | canonical | 2026-04-18 | high | XML tags, role prompting, examples, long-context ordering, output control | provider-specific behavior | Used for Claude family notes and marker guidance |
 | `https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-tools` | official docs | canonical | 2026-04-18 | medium | Prompt improver inputs: prompt, failure feedback, ideal examples | console workflow may change | Reinforces critique-plus-example loop |
@@ -68,6 +70,14 @@ Why: this skill is a repeatable prompt-optimization workflow with explicit preco
    Status: adopted
    Why: Gemini and Anthropic both document that long-context prompts perform better when evidence comes before the final query.
 
+9. Inventory stable external context by exact path.
+   Status: adopted
+   Why: AGENTS.md and Codex guidance favor explicit project instruction sources, and path inventories prevent prompts from copying stale docs or using vague "read the docs" pointers.
+
+10. Add `External Context` to the returned prompt package.
+    Status: adopted
+    Why: another engineer should see which specs, docs, policies, and examples were loaded, referenced, or left out of scope.
+
 ## Coverage matrix
 
 | Dimension | Coverage status | Evidence |
@@ -78,6 +88,7 @@ Why: this skill is a repeatable prompt-optimization workflow with explicit preco
 | Model-family variance | complete | OpenAI, Anthropic, Gemini docs |
 | Prompt compaction and deduplication | complete | OpenAI reasoning best practices, Anthropic skill best practices, Gemini long-context guidance |
 | Context ordering and query placement | complete | Anthropic prompting docs, Gemini long-context guidance |
+| External file inventories | complete | AGENTS.md format guidance, OpenAI Codex AGENTS.md docs, user concern |
 | Safety and escalation boundaries | complete | provider docs plus repo workflow conventions |
 | Output and acceptance checks | complete | OpenAI prompting and optimizer docs, skill-writer output patterns |
 | Transformed example artifacts | complete | `references/transformed-examples.md` |
@@ -108,6 +119,7 @@ Why: this skill is a repeatable prompt-optimization workflow with explicit preco
 1. Add provider notes for additional families only when the repository has a real downstream need.
 2. If this skill starts getting heavy use, add an optional script or eval template for capturing prompt scores across rounds.
 3. Re-check provider docs when major model-family updates land, especially around tool use and reasoning defaults.
+4. Add durable before/after examples for external context inventories if future prompt changes regress into vague file references.
 
 ## Stopping rationale
 
@@ -123,3 +135,4 @@ Further retrieval is currently low-yield for this first version. The source pack
 - 2026-04-18: Created the initial `prompt-optimizer` skill, references, and provenance record.
 - 2026-04-18: Added an explicit prompt learnings pass covering compaction, deduplication, and context ordering.
 - 2026-04-18: Folded the prompt learnings back into the core shaping and iteration guidance to keep the workflow compact.
+- 2026-05-04: Added exact external context inventories, `External Context` output, concise runtime workflow, and `SPEC.md`.

--- a/skills/prompt-optimizer/SPEC.md
+++ b/skills/prompt-optimizer/SPEC.md
@@ -1,0 +1,92 @@
+# Prompt Optimizer Specification
+
+## Intent
+
+`prompt-optimizer` improves reusable prompts through a contract-first, eval-backed workflow.
+
+It should produce shorter, more reliable prompt packages with explicit model strategy, external context inventory, eval evidence, and residual risks.
+
+## Scope
+
+In scope:
+
+- New agent, system, developer, and reusable prompt templates.
+- Refining existing prompts from failures or examples.
+- Porting prompts across OpenAI, Claude, Gemini, or unknown model families.
+- Prompt eval set design, candidate comparison, and holdout checks.
+- Layering stable policy, task-local context, examples, tool policy, and external file references.
+
+Out of scope:
+
+- Choosing model architecture or fine-tuning strategy except to flag when prompting is not the bottleneck.
+- Rewriting product docs, specs, or policies referenced by a prompt.
+- Creating reusable agent skills.
+- Debugging repository code unrelated to prompt behavior.
+- Asking models to reveal hidden reasoning or chain-of-thought.
+
+## Users And Trigger Context
+
+- Primary users: engineers and agents maintaining prompts for coding agents, product agents, eval harnesses, and model integrations.
+- Should trigger for: improve a prompt, optimize a system prompt, rewrite an agent prompt, tune prompt wording, make prompts reliable, port prompts across model families, build prompt evals.
+- Should not trigger for: normal code review, PR writing, skill authoring, generic documentation editing, or parameter-only tuning.
+
+## Runtime Contract
+
+- Capture the prompt contract before edits: target model, prompt surfaces, layer owners, objective, non-goals, inputs, tools, output shape, success criteria, failures, and hard constraints.
+- Build or request a small eval set when success criteria or examples are missing.
+- Inventory stable external context by exact repo-relative path.
+- Reference docs/specs/policies by path; paste only necessary excerpts.
+- Keep one authoritative owner per behavior rule.
+- Compare candidates on the same eval slice.
+- Validate the selected prompt on holdout cases.
+- Return a reusable package with target, success criteria, external context, optimized prompt, adapter notes, eval set, optimization log, and residual risks.
+
+## Source And Evidence Model
+
+Authoritative sources:
+
+- Local `prompt-optimizer` runtime files and references.
+- Repository instructions and `skill-writer` authoring rules.
+- Official OpenAI, Anthropic, and Gemini prompting and eval guidance.
+- Prompt optimization research and framework docs already captured in `SOURCES.md`.
+
+Useful improvement sources:
+
+- positive examples: prompts that meet eval targets with fewer tokens and cleaner layering
+- negative examples: prompts with duplicated policy, vague context, stale examples, or weak tool rules
+- eval outputs: failure clusters, holdout regressions, candidate scores, and optimization logs
+- model changes: provider docs or release notes showing changed behavior, tool APIs, or reasoning defaults
+
+Do not store secrets, customer data, private policy text, or long copyrighted prompt/source excerpts in examples.
+
+## Reference Architecture
+
+- `SKILL.md` contains the runtime workflow and output contract.
+- `SPEC.md` contains this maintenance contract.
+- `SOURCES.md` stores source inventory, decisions, coverage, gaps, and changelog.
+- `references/core-patterns.md` covers prompt structure, layering, markers, external files, tool policy, and symptom fixes.
+- `references/meta-optimization-loop.md` covers eval-backed iteration.
+- `references/model-family-notes.md` covers provider adapters.
+- `references/transformed-examples.md` contains compact examples for new prompts, repairs, and anti-pattern correction.
+- `scripts/` and `assets/` are unused unless prompt scoring automation or reusable templates become necessary.
+
+## Evaluation
+
+- Lightweight validation: run representative prompt tasks through the contract checklist and verify the package includes external context, eval cases, and residual risks.
+- Candidate validation: compare all candidates on the same working slice and at least one holdout case.
+- Trigger QA: confirm prompt optimization requests trigger this skill while skill writing, code review, and parameter-only tuning do not.
+- Acceptance gates: prompt is shorter or behaviorally justified, rules have one owner, external files are exact, examples are causal, and residual risks name non-prompt bottlenecks.
+
+## Known Limitations
+
+- Prompt behavior can change across model snapshots; the skill must recommend re-running evals after model changes.
+- The skill cannot prove prompt quality without representative eval cases.
+- External files referenced by path are useful only when the runtime agent can access them.
+- Provider-specific advice can drift; refresh official docs when model or API behavior matters.
+
+## Maintenance Notes
+
+- Update `SKILL.md` when runtime workflow, output package, or failure modes change.
+- Update `SPEC.md` when scope, evidence policy, evaluation, or reference architecture changes.
+- Update `SOURCES.md` when source inventory, decisions, coverage, gaps, or changelog entries change.
+- Keep reference files focused; split any file that mixes unrelated lookup needs.

--- a/skills/prompt-optimizer/references/core-patterns.md
+++ b/skills/prompt-optimizer/references/core-patterns.md
@@ -1,9 +1,6 @@
 # Core Patterns
 
-Use this file when creating a new prompt or restructuring a weak one.
-
 ## When markers help
-
 Use markers when the prompt mixes different content types:
 
 - instructions
@@ -29,26 +26,16 @@ If the target stack or model family responds better to plain markdown, use headi
 
 ### Where rules live
 
-Markers signal to the model what kind of content a block carries. Descriptive
-or state markers (`<context>`, `<state>`, `<turn-state>`, `<environment>`,
-`<artifact-state>`) read as facts about the situation — data, not policy.
-Canonical rules markers (`<behavior>`, `<constraints>`, `<tool_policy>`,
-`<workflow>`) read as directives the model should follow.
+| Block type | Examples | Content |
+|------------|----------|---------|
+| descriptive | `<context>`, `<state>`, `<environment>` | facts, inputs, current state |
+| rules | `<behavior>`, `<constraints>`, `<tool_policy>`, `<workflow>` | directives |
 
-A directive buried in a descriptive block can underperform the same directive
-placed in a rules block, especially for state-conditional rules. Observed in
-the field: a resume-notice instruction placed inside `<turn-state>resumed</turn-state>`
-scored 0.5 on the relevant eval; the identical sentence moved into
-`<behavior>` passed at ≥0.75 with no other change.
+Rules:
 
-Rules of thumb:
-
-- keep descriptive markers descriptive — put facts about the situation there,
-  not directives
-- directives live in a canonical rules section
-- for state-conditional rules, phrase them in the rules section and reference
-  the state by name: "When `<turn-state>` is `resumed`, post a brief
-  continuation notice, then answer."
+- Keep descriptive markers descriptive.
+- Put directives in canonical rules sections.
+- For state-conditional rules, write the directive in a rules section and reference the state by name.
 
 ## Layer the prompt correctly
 
@@ -95,93 +82,45 @@ Do not cargo-cult this ordering into short prompts that do not need it.
 
 ### Layered prompts with multiple owners
 
-The layers above assume a single author owns the whole system prompt. Many
-runtimes concatenate the system prompt from multiple layers with different
-owners at request time:
+When a runtime concatenates prompt layers from different owners:
 
-- a **platform layer** owned by the product or framework team (harness rules,
-  tool-use policy, output contract, safety boundaries)
-- a **deployer or persona layer** authored by the downstream user or customer
-  (voice, tone, identity files such as `SOUL.md`, `CLAUDE.md`, `AGENTS.md`)
+| Layer | Owns | Must not own |
+|-------|------|--------------|
+| platform | tool policy, output contract, safety, escalation, workflow | voice-only identity |
+| deployer/persona | voice, tone, domain framing, sparse identity files | load-bearing behavior |
+| user payload | task facts, variables, current request | durable policy |
 
-When this is the case, treat the deployer layer as **voice-only**:
+Rules:
 
-- every platform behavior rule — evidence gathering, tool-use policy, narration
-  rules, output contract, escalation boundaries — must live in the
-  platform-owned layer and must still fire if the deployer layer is empty,
-  five lines of voice, or customized in unexpected ways
-- do not delete a platform bullet on the assumption that a persona file
-  "probably covers it"; deployers ship sparse persona files in practice
-- if a rule is load-bearing, it belongs in the platform layer by default;
-  the deployer layer gets voice and domain framing, not policy
+- Platform behavior must work when `AGENTS.md`, `CLAUDE.md`, or persona files are empty or customized.
+- Do not delete platform rules because a deployer layer "probably covers it".
+- Put load-bearing rules in the highest stable owner.
 
-Hermes Agent, OpenClaw, and similar SOUL.md-style frameworks use this split
-explicitly: platform behavior is code-level, SOUL.md carries identity and
-tone, and the platform falls back to a built-in default identity if SOUL.md
-is absent or sparse. Mirror that invariant whenever a prompt is assembled
-from more than one authorship layer.
+## External file inventories
 
-## Portable agent prompt skeleton
-
-Use this as a starting point and adapt it.
-
-Tool schemas are disclosed to the model by the provider-native tools parameter
-(Anthropic `tools`, OpenAI `tools`, Gemini `tools`). On Anthropic this is
-explicit — the API constructs a special system prompt that injects the tool
-definitions from the `tools` parameter alongside the user-authored system
-prompt. Well-tuned harnesses (Codex CLI, pi-agent-core) pass tools natively
-and keep the prompt text free of schema restatements.
-
-The prompt text should carry tool *policy* — when to call tools, when to avoid
-them, what evidence to gather before acting — not a restated list of tool
-names or argument schemas. Naming a specific tool in a policy rule ("prefer
-`Read` over a `Bash` cat") is fine; re-enumerating the tool inventory or its
-schemas is not.
+Use path inventories when prompts depend on repo docs, specs, or policies.
 
 ```text
-<role>
-You are [agent role].
-</role>
-
-<goal>
-Primary objective:
-Secondary objective:
-Non-goals:
-</goal>
-
-<context>
-Available inputs:
-Available files or documents:
-Known constraints:
-</context>
-
-<tool_policy>
-When to use tools:
-When to avoid tools:
-Evidence to gather before acting:
-</tool_policy>
-
-<workflow>
-1. Clarify only if required.
-2. Gather missing facts with tools instead of guessing.
-3. Execute the task.
-4. Validate the result.
-5. Report outcome and remaining risks.
-</workflow>
-
-<constraints>
-Hard constraints:
-Soft preferences:
-Escalation boundaries:
-</constraints>
-
-<output_format>
-Progress updates:
-Final response sections:
-</output_format>
+<external_files>
+- `AGENTS.md` - repo agent rules; loaded
+- `docs/api.md` - API contract; reference before endpoint changes
+- `SECURITY.md` - security policy; reference for disclosure or auth changes
+</external_files>
 ```
 
-Use markdown headings instead of tags if that fits the target stack better.
+Rules:
+
+- Enumerate exact repo-relative paths.
+- Mark each file as `loaded`, `referenced`, or `out of scope`.
+- Paste only excerpts needed for the prompt or eval case.
+- Prefer `docs/api.md` over "read the docs".
+- Keep stable docs outside the prompt when the runtime can retrieve files.
+
+## Tool policy placement
+
+- Tool schemas belong in provider-native tools.
+- Prompt text carries tool policy: when, why, whether, evidence, and stop conditions.
+- Naming a tool in policy is fine; re-enumerating schemas is not.
 
 ## High-value prompt moves
 
@@ -190,29 +129,12 @@ Use markdown headings instead of tags if that fits the target stack better.
 - State when it should use tools and what evidence it should gather before acting.
 - State what counts as completion.
 - State what counts as refusal, escalation, or defer.
+- Enumerate external files by path when specs, docs, or policies matter.
 - Separate hard constraints from preferences.
 - Keep progress-update style explicit if the user should see it.
 - Use the shortest wording that preserves the intended behavioral constraint.
 - Remove persona, motivation, or reminder text that does not change measured behavior.
 - Place directives in canonical rules sections (`<behavior>`, `<constraints>`, `<tool_policy>`, `<workflow>`), not buried inside descriptive markers like `<context>`, `<state>`, or `<turn-state>`.
-
-## Examples
-
-Examples help most when they teach one of these:
-
-- output format
-- edge-case handling
-- tool-use triggers
-- the difference between "ask first" and "act now"
-
-Examples hurt when they:
-
-- contradict the instructions
-- overfit the model to one narrow phrasing
-- use inconsistent structure
-- show anti-patterns without a corrected version
-- restate rules that are already clear in the instructions
-- remain in the prompt after they stop improving evals
 
 ## Symptom to fix mapping
 

--- a/skills/prompt-optimizer/references/transformed-examples.md
+++ b/skills/prompt-optimizer/references/transformed-examples.md
@@ -25,6 +25,11 @@ Use tools to inspect the workspace before assuming facts.
 Read before write. Validate the changed surface before finishing.
 </tool_policy>
 
+<external_files>
+Reference exact repo files such as `AGENTS.md`, `CONTRIBUTING.md`, or
+`docs/api.md` when they govern the task.
+</external_files>
+
 <workflow>
 1. Restate the objective briefly.
 2. Inspect the relevant files or state.
@@ -43,6 +48,7 @@ Why it is better:
 
 - explicit default behavior
 - explicit tool-use trigger
+- path-backed external context
 - explicit validation step
 - explicit escalation boundary
 
@@ -111,6 +117,11 @@ Complete the user's task accurately and efficiently.
 Use tools when current repository facts, logs, or external state are needed.
 </tool_use>
 
+<external_files>
+List exact files for stable specs, docs, and policies. Paste excerpts only
+when the runtime cannot retrieve them.
+</external_files>
+
 <clarification>
 Ask only when required information is missing or the action is risky.
 </clarification>
@@ -125,44 +136,6 @@ Why it is better:
 
 - removes contradictory instructions
 - removes chain-of-thought demand
+- replaces vague context with exact file rules
 - replaces absolute slogans with operational rules
 - turns style goals into specific output behavior
-
-## Example 4: Directive placement — state marker vs. rules section
-
-### Before
-
-```text
-<turn-state>resumed</turn-state>
-This turn continues from a prior checkpoint. Post a brief continuation
-notice (e.g., "Connected — continuing.") and then the resumed answer
-as a separate message.
-```
-
-The directive is buried inside a descriptive state marker. In the field,
-this variant scored 0.5 on the relevant LLM-judged eval — the model read
-the block as situational data and combined both messages into one.
-
-### After
-
-```text
-<turn-state>resumed</turn-state>
-
-<behavior>
-When `<turn-state>` is `resumed`, post a brief continuation notice
-("Connected — continuing.") first, then send the resumed answer as a
-separate message.
-</behavior>
-```
-
-Same rule, stronger placement. The state marker stays descriptive; the
-directive moves to the canonical rules section and references the state
-by name. In the same eval, this variant passed at ≥0.75 with no other
-change.
-
-Why it is better:
-
-- keeps descriptive markers descriptive — facts, not policy
-- places the directive where the model reads directives
-- makes the state-conditional nature explicit instead of implicit
-- preserves a single authoritative owner for the rule


### PR DESCRIPTION
Tighten the agents-md and prompt-optimizer skills around concise, reference-backed guidance. AGENTS.md generation now enumerates exact external files for specs, docs, and policies, while prompt optimization captures external context before rewriting prompts.

**Skill maintenance metadata**

Adds SPEC.md and SOURCES.md for agents-md, plus SPEC.md for prompt-optimizer, so material behavior changes have maintenance contracts and provenance.

**Prompt guidance**

Adds exact external context inventory rules to prompt-optimizer and compacts the core/reference examples to keep runtime prose smaller.