### PR TITLE
fix(pr-writer): Reject bracketed PR title prefixes

### DIFF
--- a/skills/pr-writer/SKILL.md
+++ b/skills/pr-writer/SKILL.md
@@ -76,62 +76,42 @@ Refresh when follow-up commits change reviewer expectations, such as a scope cha
 
 ### Step 4: Write or Update the PR Title
 
-Write the title before the body, or re-evaluate it before finalizing the body.
+Write or re-evaluate the title before finalizing the body.
 
-**Title format** follows commit conventions:
-- `feat(scope): Add Slack thread replies for alert notifications`
-- `fix(scope): Preserve replay segment cursor across pagination`
-- `ref(scope): Extract shared project validation helper`
+Title format: `<type>(<scope>): <Subject>` or `<type>: <Subject>`.
 
-Prefer:
+Allowed types: `feat`, `fix`, `ref`, `perf`, `docs`, `test`, `build`, `ci`, `chore`, `style`, `meta`, `license`, `revert`.
+
+Rules:
 - The dominant change, not the latest commit
-- Specific nouns and verbs
 - The narrowest accurate type and scope
-- One clear change axis a reviewer can scan in a PR list
+- No bracketed labels like `[codex]`, `[claude]`, `[ai]`, `[bot]`, or `[wip]`
+- No agent, tool, or automation attribution
+- No vague process titles like `update`, `cleanup`, `misc`, `fix stuff`, or `address feedback`
+- No trailing period
 
-Avoid:
-- Vague words like `update`, `cleanup`, `misc`, `fix stuff`, or `address feedback`
-- Titles that describe the process instead of the change
-- Titles that no longer match the current branch after follow-up commits
-- Trailing periods
+Rewrite invalid titles before creating or updating the PR:
+
+- `[codex] Paginate replay segment downloads` -> `fix(replay): Paginate recording segment downloads`
 
 Use this test on updates: if a reviewer read only the title, would they still form the right expectation about the current diff? If not, rewrite it.
 
 ### Step 5: Write or Update the PR Description
 
-Use this same structure whether you are opening a new PR or updating an existing PR body. When updating, rewrite the final PR body so it still matches this structure instead of appending ad hoc notes or preserving repository template sections.
-
 Write reviewer-facing prose, not a narrated diff.
 
-The opening summary should usually:
-- Name the primary change
-- Explain the practical effect or behavior change
-- Give the why only when it is not already obvious from the change itself
-
-Prefer:
-- Concrete nouns and verbs
-- The changed behavior before implementation detail
-- Short declarative sentences
-- Details that help a reviewer understand impact, risk, or why the code is shaped this way
-
-Avoid:
-- Throat-clearing like `This PR`, `basically`, `simply`, `just`, `some`, `various`, or `in order to`
-- Empty claims like `improves things`, `cleans things up`, or `makes this better` without saying how
-- File-by-file narration
-- Repeating the diff without adding meaning
-- Long setup or project history before the actual change
-
-When a sentence only restates what the diff already makes obvious, delete it.
-
-Use this structure for PR descriptions, ignoring any repository PR templates:
+Use this structure, ignoring repository PR templates:
 
 ```markdown
 <1-3 sentence summary of the change and why it matters. Keep this short.>
 ```
 
-When there is a known issue, ticket, or related PR, add references at the end. Do not invent one.
-
-When the PR has distinct changes reviewers should scan, add 0-3 bold emphasis blocks after the opening summary:
+Rules:
+- Lead with changed behavior, then implementation detail only when useful
+- Add 0-3 bold emphasis blocks for distinct reviewer-relevant changes
+- Use before/after fenced blocks only for changed contracts, output shapes, config, CLI output, payloads, permissions, or input formats
+- Add known issue references at the end; do not invent references
+- Cut file-by-file narration, copied commit logs, generic headings like "Summary" or "Changes", and stale template scaffolding
 
 ```markdown
 **<Important Change>**
@@ -139,53 +119,13 @@ When the PR has distinct changes reviewers should scan, add 0-3 bold emphasis bl
 <1-2 sentences explaining the important implementation, behavior, or review-relevant change.>
 ```
 
-When direct comparison is the clearest explanation, add a before/after block under the relevant paragraph or emphasis block:
-
-````markdown
-Before, <old shape or behavior in one sentence>:
-
-```<format-or-pseudocode>
-...
-```
-
-After, <new shape or behavior in one sentence>:
-
-```<format-or-pseudocode>
-...
-```
-````
-
-Treat the bold sections as optional emphasis blocks, not mandatory headings. Use them when the PR has one or more distinct changes that reviewers should scan quickly. Omit them for simple PRs where the opening summary is enough.
-
-Use before/after examples only when that is the clearest way to explain the changeset. They are usually useful for changed contracts or output shapes, such as JSON responses, schemas, config, CLI output, event payloads, permissions, or input formats. Omit them when prose is clearer.
-
-Prefer:
-- A concise opening summary, usually 1-3 sentences
-- 0-3 bold emphasis blocks for the parts that matter most
-- Before/after examples only for changes that benefit from direct comparison, with separate fenced blocks for the old and new forms
-- Known issue references at the end, when available
-
-Avoid:
-- Essays, exhaustive file-by-file walkthroughs, or copied commit logs
-- Generic headings like "Summary" or "Changes"
-- A bold block for every touched file
-- Inline before/after snippets that are hard to compare
-- Placeholder issue references when no issue is known
-- Repeating details that are obvious from the diff
-
-**Do NOT include:**
+Do not include:
 - "Test plan" sections
 - Checkbox lists of testing steps
 - Redundant summaries of the diff
 - Customer data — customer/org names, user emails, support ticket contents, or PII. Describe the technical symptom, not who hit it, and if available, reference the internal ticket (e.g. `Fixes SENTRY-1234`). PRs are typically public on open-source repos.
 
-**Do include:**
-- Clear explanation of what changed and why it matters
-- Links to relevant issues or tickets, when known
-- Context that isn't obvious from the code
-- Specific review notes when a part of the diff needs extra attention
-
-If the existing PR body has stale context, repo-template scaffolding, or a delta-only update note, remove or rewrite it so the final body reads as one coherent description of the current PR.
+When updating, rewrite the body as one coherent description of the current PR.
 
 ### Step 6: Create or Update the PR
 
@@ -202,7 +142,7 @@ For an existing PR, patch the title and body after you have re-evaluated both. I
 
 ```bash
 gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER \
-  -f title='new: Title' \
+  -f title='fix(scope): Preserve replay segment cursor' \
   -f body="$(cat <<'EOF'
 <updated description body here>
 EOF

--- a/skills/pr-writer/SPEC.md
+++ b/skills/pr-writer/SPEC.md
@@ -4,7 +4,7 @@
 
 The `pr-writer` skill creates and updates pull requests with concise, review-oriented titles and descriptions that match Sentry conventions.
 
-Its main job is to turn branch changes into reviewer-facing prose that explains what changed, why it changed, and the few details reviewers need before reading the diff. It should avoid long essays, mechanical diff summaries, and vague titles that no longer match the branch scope.
+Its main job is to turn branch changes into reviewer-facing prose that explains what changed, why it changed, and the few details reviewers need before reading the diff. It should avoid long essays, mechanical diff summaries, agent/tool attribution markers, and vague titles that no longer match the branch scope.
 
 ## Scope
 
@@ -14,6 +14,7 @@ In scope:
 - Updating existing PRs by re-evaluating both title and body against the current diff.
 - Producing compact PR bodies with optional bold emphasis sections.
 - Producing titles that accurately describe the dominant change in the PR.
+- Rejecting bracketed agent, bot, or tool prefixes in PR titles.
 - Including issue references and review context when useful.
 
 Out of scope:
@@ -34,7 +35,7 @@ Out of scope:
 - Required first actions: verify the current branch, committed state, base branch, and diff scope before writing or updating a PR; when updating, inspect the current PR title and body before deciding what to keep.
 - Required outputs: a conventional PR title and a concise PR body suitable for `gh pr create` or GitHub API update commands; on updates, include an explicit keep-or-rewrite decision for the title.
 - Required update behavior: if an open PR exists and follow-up commits materially change reviewer expectations, refresh the PR even when the user did not explicitly ask for a PR edit.
-- Non-negotiable constraints: never include customer data or PII, ignore repository PR templates, omit test-plan sections, and prefer draft PRs for newly opened pull requests.
+- Non-negotiable constraints: never include customer data or PII, never use bracketed agent/tool labels such as `[codex]` in PR titles, ignore repository PR templates, omit test-plan sections, and prefer draft PRs for newly opened pull requests.
 - Expected bundled files loaded at runtime: only `SKILL.md`.
 
 ## Source And Evidence Model
@@ -53,6 +54,7 @@ Useful improvement sources:
 - positive examples: PR titles that stay specific after follow-up commits.
 - negative examples: PR bodies that read like essays, repeat the diff, or overuse headings.
 - negative examples: PR titles that are vague, process-oriented, or stale after scope changes.
+- negative examples: PR titles that use bracketed agent/tool labels instead of conventional commit types, such as `[codex] Paginate replay segment downloads`.
 - negative examples: branches with material follow-up commits where the agent pushed changes but left the PR title/body stale.
 - commit logs/changelogs: only as source context, not as body text to paste.
 - issue or PR feedback: reviewer comments about missing context or excessive detail.
@@ -80,7 +82,7 @@ Data that must not be stored:
 - Holdout examples: include at least one simple PR that should have no bold section, one PR with no known issue reference, and one API or input-format change that should use separate before/after fenced blocks.
 - Holdout examples: include at least one PR update where the old title no longer matches the final diff and must be rewritten.
 - Holdout examples: include at least one review-feedback or follow-up-commit scenario where the skill should refresh an open PR without an explicit PR-update request.
-- Acceptance gates: output title matches the dominant change, update flows explicitly re-evaluate whether the existing title still fits, material follow-up commits to an open PR trigger a refresh even without an explicit PR-update request, output begins with a 1-3 sentence summary, summary prose leads with the changed behavior before implementation detail, uses no required generic headings, includes at most a few bold emphasis blocks, uses before/after examples only when direct comparison is the clearest explanation, omits unknown issue references instead of inventing placeholders, avoids test-plan sections, and does not include customer data.
+- Acceptance gates: output title uses an allowed Sentry conventional commit type, contains no bracketed agent/tool prefix, matches the dominant change, update flows explicitly re-evaluate whether the existing title still fits, material follow-up commits to an open PR trigger a refresh even without an explicit PR-update request, output begins with a 1-3 sentence summary, summary prose leads with the changed behavior before implementation detail, uses no required generic headings, includes at most a few bold emphasis blocks, uses before/after examples only when direct comparison is the clearest explanation, omits unknown issue references instead of inventing placeholders, avoids test-plan sections, and does not include customer data.
 
 ## Known Limitations
 


### PR DESCRIPTION
Make `pr-writer` require conventional PR titles and reject bracketed agent/tool prefixes like `[codex]`. The title guidance now points invalid prefixes to a conventional `fix(...)` title, and the surrounding body guidance is shorter so the skill stays compact. Update the spec acceptance gates so bracketed agent/tool title prefixes are explicitly invalid.