### PR TITLE
chore(ci): bump create-github-app-token from v1 to v3

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.WARDEN_APP_ID }}


### PR DESCRIPTION
## Summary

- Bump `actions/create-github-app-token` from `@v1` to the floating major `@v3` in `.github/workflows/warden.yml`.
- `@v1` is two major versions behind upstream. v3.2.0 (released 2026-05-12) adds explicit handling for the new `X-GitHub-Stateless-S2S-Token` header that GitHub introduced as part of the upcoming installation-token format rollout — see the [GitHub Changelog from 2026-05-15](https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/).
- Floating `@v3` keeps Warden on the supported major and picks up future patch/minor releases without further bumps.

## Why

GitHub is rolling out a new stateless (JWT) installation-token format. Recent versions of `actions/create-github-app-token` handle the rollout transparently. Older `@v1` is still maintained at best on a best-effort basis and missed several refactors of the underlying token-issuance flow.

## Test plan

- [ ] `Warden` workflow runs successfully on this PR.
- [ ] `actions/create-github-app-token@v3` resolves to v3.2.0 (or newer) and produces a valid token for the `getsentry/warden@v0` step.