### PR TITLE
docs(pr-writer): Favor natural PR descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Works with Claude Code, Cursor, Cline, GitHub Copilot, and other compatible agen
 | [iterate-pr](skills/iterate-pr/SKILL.md) | Iterate on a PR until CI passes and actionable review feedback is addressed. |
 | [presentation-creator](skills/presentation-creator/SKILL.md) | Create data-driven presentation slides using React, Vite, and Recharts with Sentry branding. |
 | [pr-link-issue](skills/pr-link-issue/SKILL.md) | Append a GitHub issue link and its Linear ticket to the current PR's description. |
-| [pr-writer](skills/pr-writer/SKILL.md) | Canonical workflow to create and update pull requests following Sentry conventions. |
+| [pr-writer](skills/pr-writer/SKILL.md) | Create, refresh, and rewrite pull request titles and descriptions following Sentry conventions. |
 | [prompt-optimizer](skills/prompt-optimizer/SKILL.md) | Optimize prompts with evals, model-family adapters, and exact external context references. |
 | [replay-ux-research](skills/replay-ux-research/SKILL.md) | Analyze Sentry session replays to surface UX patterns, pain points, and user journeys for a given product area. |
 | [security-review](skills/security-review/SKILL.md) | Security code review for vulnerabilities. |

--- a/skills/pr-writer/SKILL.md
+++ b/skills/pr-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-writer
-description: Create and update pull requests following Sentry conventions. Use when opening a PR or refreshing an existing PR after material changes.
+description: Create, refresh, and rewrite PR titles and descriptions following Sentry conventions. Use when opening a PR, writing or updating a PR title/body/description, refreshing an existing PR after material changes, or preparing branch changes for review.
 ---
 
 # PR Writer
@@ -98,32 +98,42 @@ Use this test on updates: if a reviewer read only the title, would they still fo
 
 ### Step 5: Write or Update the PR Description
 
-Write reviewer-facing prose, not a narrated diff.
+Write a reviewer-facing cover note, not a generated changelog.
 
-Use this structure, ignoring repository PR templates:
+Default to 1-2 short paragraphs:
 
 ```markdown
-<1-3 sentence summary of the change and why it matters. Keep this short.>
+<What changed and what effect it has.>
+
+<Why this approach, tradeoff, risk, or review focus matters, if it is not obvious from the diff.>
 ```
+
+Write enough context that a reviewer can predict the shape and intent of the diff before opening it. The body should answer the questions that code alone will not: why the change exists, what behavior changes, what tradeoff was chosen, and what deserves careful review.
+
+Use structure only when the change needs it:
+
+| Change shape | Useful body shape |
+|--------------|-------------------|
+| Small obvious change | one concise paragraph; no headings |
+| Bug fix | problem/root cause/fix in prose; headings only if the body would be confusing without them |
+| API, schema, payload, config, permissions, or CLI change | before/after fenced blocks when direct comparison is clearer than prose |
+| Performance or reliability change | include measured impact or expected tradeoff when known; do not invent numbers |
+| Broad, generated, or cross-cutting change | explain the organizing principle and where reviewers should start |
+| Review feedback update | rewrite the whole body around the current final diff; do not append a progress log |
 
 Rules:
-- Lead with changed behavior, then implementation detail only when useful
-- Add 0-3 bold emphasis blocks for distinct reviewer-relevant changes
-- Use before/after fenced blocks only for changed contracts, output shapes, config, CLI output, payloads, permissions, or input formats
-- Include issue references only when the exact ID or URL is present in user input, branch name, commits, or verified tracker output — omit the line entirely otherwise
-- Cut file-by-file narration, copied commit logs, generic headings like "Summary" or "Changes", and stale template scaffolding
+- Lead with changed behavior or effect, then implementation detail only when useful.
+- Prefer paragraphs over headings and bullets.
+- Use bullets only to guide review order, list genuine alternatives/tradeoffs, or compare independent contract changes.
+- When verification matters, fold it into the relevant prose instead of adding a separate checklist.
+- Include issue references only when the exact ID or URL is present in user input, branch name, commits, or verified tracker output; omit the line entirely otherwise.
+- Keep links self-contained by summarizing the relevant context in the body.
+- Prefer synthesized reviewer context over file-by-file narration, copied commit logs, generic headings like "Summary" or "Changes", and stale template scaffolding.
 
-```markdown
-**<Important Change>**
-
-<1-2 sentences explaining the important implementation, behavior, or review-relevant change.>
-```
-
-Do not include:
-- "Test plan" sections
-- Checkbox lists of testing steps
-- Redundant summaries of the diff
-- Customer data — customer/org names, user emails, support ticket contents, or PII. Describe the technical symptom, not who hit it, and if available, reference the internal ticket (e.g. `Fixes SENTRY-1234`). PRs are typically public on open-source repos.
+Hard constraints:
+- Customer data — customer/org names, user emails, support ticket contents, or PII. Describe the technical symptom, not who hit it, and use the Issue References syntax below only when a verified ticket is available. PRs are typically public on open-source repos.
+- Never invent issue references or leave placeholders like `XXXXX`, `<issue>`, or `TODO`.
+- Generate reviewer prose only. Do not add new agent trace links, "action taken on behalf" lines, or tool attribution. When refreshing an existing PR, preserve an existing integration-owned footer only if it appears intentional and the user did not ask to remove it.
 
 When updating, rewrite the body as one coherent description of the current PR.
 
@@ -156,39 +166,38 @@ EOF
 ### Simple PR
 
 ```markdown
-Collapse the AI Customizations section by default in the sessions sidebar.
-
-The section now starts hidden so it does not consume space before users need
-it. Users who expand it keep the same persisted preference behavior as before.
+The AI Customizations section in the sessions sidebar now starts collapsed so
+it does not consume space before users need it. Expanding the section keeps the
+same persisted preference behavior as before.
 ```
 
 ### Feature PR
 
 ```markdown
-Add Slack thread replies for alert notifications
+Alert updates and resolves now reply to the original Slack message instead of
+creating a new channel message. This keeps the notification timeline grouped in
+one thread and reduces channel noise.
+```
 
-When an alert is updated or resolved, we now post a reply to the original
-Slack thread instead of creating a new message. This keeps related
-notifications grouped and reduces channel noise.
+### Bug Fix PR
 
-**Notification Threading**
+```markdown
+Inactive authenticated users now go to account reactivation before the login
+view honors a `next` URL.
 
-Resolved and updated alerts now reply to the original Slack message instead
-of creating a new channel message.
-
-Refs SENTRY-1234
+The GET login path could previously bounce an inactive user between
+`/auth/login/` and a protected view because it redirected authenticated users
+without checking `is_active`. The POST path already handled this case, so this
+applies the same guard to the GET redirect and covers the loop with a regression
+test.
 ```
 
 ### Schema Change PR
 
 ````markdown
-Switch run logs to chunk-level JSONL records
-
 Run logs now write one versioned record per analyzed chunk instead of one
 large skill-level record. This lets `warden runs follow` show findings as
 chunks complete while preserving durable run reconstruction at finalization.
-
-**JSONL Shape**
 
 Before, each line represented a full skill result:
 
@@ -220,24 +229,29 @@ After, each line represents one chunk result:
 }
 ```
 
-Refs WARDEN-123
 ````
 
 ### Refactor PR
 
 ````markdown
-Extract validation logic to shared module
-
-Moves duplicate validation code from the alerts, issues, and projects
-endpoints into a shared validator class. No behavior change.
-
-**Shared Validator**
-
-The shared class keeps the existing endpoint behavior but gives future
-validation rules one place to live.
-
-Refs SENTRY-9999
+Duplicate validation code from the alerts, issues, and projects endpoints now
+lives in a shared validator class without changing endpoint behavior.
+Future validation rules can now be added in one place instead of being copied
+across each endpoint.
 ````
+
+### Broad Review PR
+
+```markdown
+The admin layout now holds together at narrow viewport widths: the shared
+header, details grid, result table, and sidebar wrap, collapse, or scroll
+instead of overflowing the viewport. The changes are intentionally limited to
+responsive layout behavior; table column prioritization is left out because it
+needs product judgment.
+
+Review the shared layout and table wrappers first, then check individual
+component breakpoints for regressions.
+```
 
 ## Issue References
 

--- a/skills/pr-writer/SPEC.md
+++ b/skills/pr-writer/SPEC.md
@@ -4,7 +4,7 @@
 
 The `pr-writer` skill creates and updates pull requests with concise, review-oriented titles and descriptions that match Sentry conventions.
 
-Its main job is to turn branch changes into reviewer-facing prose that explains what changed, why it changed, and the few details reviewers need before reading the diff. It should avoid long essays, mechanical diff summaries, agent/tool attribution markers, and vague titles that no longer match the branch scope.
+Its main job is to turn branch changes into a reviewer-facing cover note that explains what changed, why it changed, and the few details reviewers need before reading the diff. It should avoid long essays, mechanical diff summaries, fill-in-the-template prose, agent/tool attribution markers, and vague titles that no longer match the branch scope.
 
 ## Scope
 
@@ -12,7 +12,7 @@ In scope:
 
 - Creating draft pull requests from committed feature branches.
 - Updating existing PRs by re-evaluating both title and body against the current diff.
-- Producing compact PR bodies with optional bold emphasis sections.
+- Producing natural PR bodies that default to short paragraphs and use structure only when the change shape needs it.
 - Producing titles that accurately describe the dominant change in the PR.
 - Rejecting bracketed agent, bot, or tool prefixes in PR titles.
 - Including issue references and review context when useful.
@@ -22,7 +22,7 @@ Out of scope:
 - Writing commits or deciding commit history policy.
 - Running full CI or iterating on failing checks.
 - Producing release notes, changelogs, or customer-facing announcements.
-- Including test-plan checklists in PR bodies.
+- Including mechanical test-plan checklists in PR bodies.
 
 ## Users And Trigger Context
 
@@ -33,9 +33,9 @@ Out of scope:
 ## Runtime Contract
 
 - Required first actions: verify the current branch, committed state, base branch, and diff scope before writing or updating a PR; when updating, inspect the current PR title and body before deciding what to keep.
-- Required outputs: a conventional PR title and a concise PR body suitable for `gh pr create` or GitHub API update commands; on updates, include an explicit keep-or-rewrite decision for the title.
+- Required outputs: a conventional PR title and a concise, natural PR body suitable for `gh pr create` or GitHub API update commands; on updates, include an explicit keep-or-rewrite decision for the title.
 - Required update behavior: if an open PR exists and follow-up commits materially change reviewer expectations, refresh the PR even when the user did not explicitly ask for a PR edit.
-- Non-negotiable constraints: never include customer data or PII, never use bracketed agent/tool labels such as `[codex]` in PR titles, ignore repository PR templates, omit test-plan sections, and prefer draft PRs for newly opened pull requests.
+- Non-negotiable constraints: never include customer data or PII, never use bracketed agent/tool labels such as `[codex]` in PR titles, never invent issue references, generate reviewer prose rather than tool attribution, ignore repository PR templates, and prefer draft PRs for newly opened pull requests.
 - Expected bundled files loaded at runtime: only `SKILL.md`.
 
 ## Source And Evidence Model
@@ -45,20 +45,23 @@ Authoritative sources:
 - Sentry engineering practices for code review.
 - Sentry commit message conventions.
 - Repository-level agent instructions.
-- Observed user preference for short PR bodies with optional bold emphasis sections.
-- `getsentry/warden#265` as a formatting exemplar for before/after examples on schema and output-shape changes.
+- Google Engineering Practices guidance for CL descriptions.
+- Git and Linux kernel patch submission guidance.
+- GitHub pull request reviewability guidance.
+- Observed user rejection of programmatic PR descriptions and preference for concise reviewer context.
+- `getsentry/warden#265` as a formatting exemplar for before/after examples on schema and output-shape changes, only when direct comparison is warranted.
 
 Useful improvement sources:
 
-- positive examples: PR descriptions that reviewers can scan quickly.
+- positive examples: PR descriptions that read like a human cover note and give reviewers the missing context.
 - positive examples: PR titles that stay specific after follow-up commits.
-- negative examples: PR bodies that read like essays, repeat the diff, or overuse headings.
+- negative examples: PR bodies that read like essays, repeat the diff, overuse headings, mirror a template, or leak internal agent process.
 - negative examples: PR titles that are vague, process-oriented, or stale after scope changes.
 - negative examples: PR titles that use bracketed agent/tool labels instead of conventional commit types, such as `[codex] Paginate replay segment downloads`.
 - negative examples: branches with material follow-up commits where the agent pushed changes but left the PR title/body stale.
 - commit logs/changelogs: only as source context, not as body text to paste.
 - issue or PR feedback: reviewer comments about missing context or excessive detail.
-- eval results: prompt-based checks for title accuracy, concise summaries, optional sections, and privacy boundaries.
+- eval results: prompt-based checks for title accuracy, natural reviewer prose, justified structure, verified references, and privacy boundaries.
 
 Data that must not be stored:
 
@@ -69,7 +72,7 @@ Data that must not be stored:
 
 ## Reference Architecture
 
-- `SKILL.md` contains runtime workflow, command patterns, PR body template, examples, and safety constraints.
+- `SKILL.md` contains runtime workflow, command patterns, conditional PR body guidance, examples, and safety constraints.
 - `references/` contains no files currently; add focused style or evidence examples only if the runtime file becomes too long or repeated regressions show the examples need more room.
 - `references/evidence/` contains no files currently; use it for durable positive and negative PR body examples if iteration data accumulates.
 - `scripts/` contains no files currently.
@@ -77,17 +80,17 @@ Data that must not be stored:
 
 ## Evaluation
 
-- Lightweight validation: compare generated titles and PR bodies against representative feature, schema-change, and refactor prompts for brevity, clarity, optional-section use, issue references, update-path title handling, and privacy handling.
+- Lightweight validation: compare generated titles and PR bodies against representative feature, bug-fix, schema-change, broad-review, and refactor prompts for brevity, clarity, justified structure, issue references, update-path title handling, and privacy handling.
 - Deeper evaluation: maintain a small prompt set with expected body shapes if regressions recur.
-- Holdout examples: include at least one simple PR that should have no bold section, one PR with no known issue reference, and one API or input-format change that should use separate before/after fenced blocks.
+- Holdout examples: include at least one simple PR that should be one paragraph, one bug fix that should explain root cause without file bullets, one PR with no known issue reference, and one API or input-format change that should use separate before/after fenced blocks.
 - Holdout examples: include at least one PR update where the old title no longer matches the final diff and must be rewritten.
 - Holdout examples: include at least one review-feedback or follow-up-commit scenario where the skill should refresh an open PR without an explicit PR-update request.
-- Acceptance gates: output title uses an allowed Sentry conventional commit type, contains no bracketed agent/tool prefix, matches the dominant change, update flows explicitly re-evaluate whether the existing title still fits, material follow-up commits to an open PR trigger a refresh even without an explicit PR-update request, output begins with a 1-3 sentence summary, summary prose leads with the changed behavior before implementation detail, uses no required generic headings, includes at most a few bold emphasis blocks, uses before/after examples only when direct comparison is the clearest explanation, omits unknown issue references instead of inventing placeholders, avoids test-plan sections, and does not include customer data.
+- Acceptance gates: output title uses an allowed Sentry conventional commit type, contains no bracketed agent/tool prefix, matches the dominant change, update flows explicitly re-evaluate whether the existing title still fits, material follow-up commits to an open PR trigger a refresh even without an explicit PR-update request, output reads like natural reviewer-facing prose, default body uses paragraphs instead of generic headings, structure is present only when justified by the change shape, before/after examples appear only when direct comparison is the clearest explanation, unknown issue references are omitted instead of invented, verification appears only as reviewer-relevant context, generated tool attribution is absent, and customer data is excluded.
 
 ## Known Limitations
 
 - The skill cannot guarantee that issue references are correct unless the branch, commits, or user provide them. It must omit references rather than invent placeholders.
-- It relies on the agent's judgment to decide whether a bold emphasis block is useful.
+- It relies on the agent's judgment to decide when a heading, bullet list, or before/after block helps reviewers more than plain paragraphs.
 - It relies on the agent's judgment to decide when a title is still accurate enough to keep versus rewrite.
 - Very large PRs may still need more context than the default body shape encourages.
 


### PR DESCRIPTION
pr-writer now steers agents toward reviewer-facing cover notes instead of block-style generated changelogs. The body guidance defaults to short natural prose, uses structure only when the change shape needs it, and keeps issue-reference syntax out of copyable examples.

The hard safeguards stay focused on privacy, verified issue references, and avoiding generated tool attribution. The refreshed examples show the style we want agents to produce, and the structural skill validator still passes.