### PR TITLE
docs(pr-writer): Improve PR description guidance

### DIFF
--- a/skills/pr-writer/SKILL.md
+++ b/skills/pr-writer/SKILL.md
@@ -5,152 +5,265 @@ description: Create, refresh, and rewrite PR titles and descriptions following S
 
 # PR Writer
 
-Create pull requests following Sentry's engineering practices.
+Create or refresh PRs with reviewer-facing titles and bodies. The body is a
+cover note, not a changelog, template, validation log, or file-by-file summary.
 
-**Requires**: GitHub CLI (`gh`) authenticated and available.
+## Output Priorities
 
-## Prerequisites
+1. Match the full branch diff against the base branch, not the latest commit or
+   stale PR text.
+2. Describe the shape and effect of the change before implementation detail.
+3. Explain why, risk, tradeoff, migration, or review focus only when useful.
+4. Use the smallest structure that makes review easier.
+5. Omit routine validation, unverified issue refs, customer data, PII,
+   placeholders, and tool traces.
 
-Before creating a PR, ensure all changes are committed **to a feature branch**, not to the default branch.
+## Plain-Language Pass
+
+Before creating or updating the PR, reread the title and body as a reviewer.
+
+- Name changed behavior, affected surface, and reviewer impact.
+- Avoid prompt/process words: `decision model`, `expanded contract`, `runtime
+  guidance`, `validation results`, `this PR updates`.
+- Replace generic sentences with specifics, or delete them.
+
+## Body Shape
+
+Classify the PR, then write the minimum useful body.
+
+| Shape | Use |
+|-------|-----|
+| Small obvious | One concise paragraph; no headings. |
+| Bug fix | Problem/root cause/fix, plus regression coverage if relevant. |
+| Feature | New behavior, user/developer effect, and non-obvious approach. |
+| Refactor | What moved, what behavior stays unchanged, and why it helps. |
+| API/schema/payload/config/permission/event/storage/CLI | Changed contract plus compact before/after, schema, or interface if clearer than prose. |
+| Breaking/removal/deprecation | Affected surface, compatibility impact, and migration/rollout guidance when known. |
+| Performance/reliability | Expected impact, measured numbers when known, and tradeoffs or failure modes. |
+| UI | User-visible effect; mention screenshots/recordings only when available and useful. |
+| Workflow/queue/async/state/multi-service | Flow summary; use a small Mermaid diagram only if prose is harder to follow. |
+| Broad/generated/cross-cutting | Organizing principle, why it is broad, and where reviewers should start. |
+| Review-feedback update | Fresh description of the whole PR diff; no review-history narration. |
+
+Default:
+
+```markdown
+<What changed and what effect it has.>
+
+<Why this approach, tradeoff, risk, migration, or review focus matters, if not
+obvious from the diff.>
+```
+
+## Optional Reviewer Aids
+
+Use only when they reduce reviewer reconstruction work:
+
+- `before/after`: contracts, payloads, config, CLI, or behavior comparisons.
+- `schema/interface`: new or changed API response, type, event, storage record,
+  config, or payload surface.
+- `mermaid`: async flows, queues, retries, lifecycle, state transitions, or
+  multi-component interaction.
+- `screenshot/recording note`: visual UI changes when evidence exists.
+- `review order`: broad, generated, mechanical, or layered diffs.
+- `rollout/migration/compatibility/deprecation note`: adopters or operators must
+  adjust or watch risk.
+- `risk/tradeoff callout`: known limits, chosen cost, or changed failure mode.
+
+Avoid aids that duplicate obvious code, decorate the body, or make prose less
+clear. Put one sentence before an artifact telling reviewers what to notice.
+
+## Titles
+
+Format: `<type>(<scope>): <subject>` or `<type>: <subject>`.
+For breaking changes, use `<type>(<scope>)!: <subject>` or
+`<type>!: <subject>` and explain the affected surface in the body.
+
+Allowed types: `feat`, `fix`, `ref`, `perf`, `docs`, `test`, `build`, `ci`,
+`chore`, `style`, `meta`, `license`, `revert`.
+
+Rules:
+
+- Describe the dominant change, not the latest commit.
+- Use the narrowest accurate type and scope.
+- Use `!` only for breaking contract, migration, removal, or compatibility
+  changes that reviewers and adopters need to notice.
+- No bracketed labels: `[codex]`, `[claude]`, `[ai]`, `[bot]`, `[wip]`.
+- No agent, tool, or automation attribution.
+- No vague titles: `update`, `cleanup`, `misc`, `fix stuff`,
+  `address feedback`.
+- No trailing period.
+
+Examples:
+
+```text
+fix(replay): Paginate recording segment downloads
+feat(api)!: Emit chunk-level run log records
+```
+
+When updating a PR, keep the current title only if a reviewer reading it alone
+would expect the whole branch diff against the base branch.
+
+## Hard Negatives
+
+- No default `Summary`, `Changes`, or `Test Plan` template.
+- No empty headings, placeholders, `TODO`, `XXXXX`, or `<issue>`.
+- No pasted command transcripts, CI logs, or validation dumps.
+- No "tests passed" or validator summary unless it changes reviewer risk
+  assessment or explains coverage for changed behavior.
+- No copied commit log.
+- No file-by-file narration unless needed for review order.
+- No agent trace links or "action taken on behalf" lines.
+- No customer/org names, user emails, support ticket contents, secrets, or PII.
+
+For docs, skill, copy, config, or other non-runtime changes, default to omitting
+validation entirely.
+
+## Examples
+
+### Small
+
+```markdown
+The AI Customizations section in the sessions sidebar now starts collapsed so it
+does not consume space before users need it. Expanding the section keeps the
+same persisted preference behavior as before.
+```
+
+### Bug Fix
+
+```markdown
+Inactive authenticated users now go through account reactivation before the
+login view honors a `next` URL.
+
+The GET login path previously redirected authenticated users without checking
+`is_active`, which could bounce an inactive user between `/auth/login/` and a
+protected view. The POST path already handled this case, so this applies the
+same guard to GET and covers the loop with a regression test.
+```
+
+### Breaking Contract
+
+````markdown
+Run logs now emit chunk-level records instead of one skill-level record with all
+findings. Consumers that read top-level `findings` need to iterate over
+`chunk.findings` for each record instead.
+
+Before:
+
+```jsonc
+{"skill": "security-review", "findings": [...], "files": [...]}
+```
+
+After:
+
+```jsonc
+{"schemaVersion": 1, "chunk": {"index": 1, "total": 2, "findings": [...]}}
+```
+````
+
+### Workflow
+
+````markdown
+Replay export now retries failed segment uploads without restarting the whole
+export. Successful segments stay committed, and the worker only requeues the
+failed segment with the existing retry limit.
+
+The changed flow is:
+
+```mermaid
+sequenceDiagram
+  participant Worker
+  participant Storage
+  participant Queue
+  Worker->>Storage: upload segment
+  Storage-->>Worker: transient failure
+  Worker->>Queue: requeue segment retry
+```
+````
+
+### Broad Or Generated
+
+```markdown
+The TypeScript API fixtures were regenerated from the updated OpenAPI schema so
+client tests match the current response shapes. The generated files stay in
+this PR because the schema and fixture updates are easiest to review together.
+
+Review the schema diff first, then treat the fixture changes as generated
+output from that contract change.
+```
+
+### Docs Or Skill Change
+
+```markdown
+The `pr-writer` skill now steers PR descriptions toward the full branch diff
+instead of the latest commit or a generated template. Small changes should stay
+short, while breaking changes, schema updates, generated diffs, and workflow
+changes get the extra context reviewers need.
+
+Schemas, before/after examples, Mermaid diagrams, rollout notes, and review
+order are treated as optional reviewer aids, not default sections. Routine
+validation stays out of PR bodies unless it changes review risk.
+```
+
+### Anti-Pattern: Validation Dump
+
+```markdown
+## Summary
+- Updated files
+- Added tests
+
+## Test Plan
+- pnpm test
+- pnpm lint
+```
+
+Corrected:
+
+```markdown
+Project creation now rejects duplicate slugs before writing the project row,
+which prevents the follow-up task from enqueueing work for a project that will
+roll back. The regression test covers the duplicate-slug path that previously
+raised after the task was already scheduled.
+```
+
+## Workflow
+
+Requires authenticated `gh`.
+
+Inspect branch, status, base branch, commits, and diff. For existing PRs, set
+`BASE` from `baseRefName`; for new PRs, use the repo default branch:
 
 ```bash
-# Check current branch and for uncommitted changes
 git branch --show-current
 git status --porcelain
-```
-
-If on `main` or `master`, create a feature branch and move any uncommitted changes onto it before committing — a PR cannot be opened from the default branch against itself. If there are uncommitted changes, commit them on the feature branch before proceeding.
-
-## Process
-
-### Step 1: Verify Branch State
-
-```bash
-# Detect the default branch — note the output for use in subsequent commands
-gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
-```
-
-```bash
-# Check current branch and status (substitute the detected branch name above for BASE)
-git status
+BASE=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
 git log BASE..HEAD --oneline
-```
-
-Ensure:
-- All changes are committed
-- Branch is up to date with remote
-- Changes are rebased on the base branch if needed
-
-### Step 2: Analyze Changes
-
-Review what will be included in the PR:
-
-```bash
-# See all commits that will be in the PR (substitute detected branch name for BASE)
-git log BASE..HEAD
-
-# See the full diff
 git diff BASE...HEAD
 ```
 
-Understand the scope and purpose of all changes before writing the description.
+If on `main` or `master`, create a feature branch first. Ensure intended
+changes are committed and the diff is reviewable as one PR.
 
-### Step 3: Check Existing PR
-
-If the current branch already has an open PR, inspect the current title and body before rewriting either one:
+For existing PRs, inspect current text and use `baseRefName` as `BASE`:
 
 ```bash
 gh pr view PR_NUMBER --json number,title,body,url,baseRefName,headRefName
 ```
 
-Treat the current PR title and body as inputs, not source of truth. Compare them against the current diff, not the diff from when the PR was first opened.
+Refresh when follow-up commits change scope, implementation approach, breaking
+behavior, risk, or final review expectations. Skip typo-only, formatting-only,
+or rename-only follow-ups. Rewrite the body around the whole PR diff; do not
+append review-history notes.
 
-When refreshing a PR:
-- Keep the current title only if it still matches the dominant change.
-- Rewrite vague or stale titles.
-- Rewrite the body as a fresh description of the current diff, not an append-only update log.
-
-If the branch already has an open PR, refresh it after material follow-up changes even if the user did not explicitly ask for a PR edit.
-
-Refresh when follow-up commits change reviewer expectations, such as a scope change, a new implementation approach from review feedback, or new context the current title/body no longer explains. Skip trivial edits like typos or rename-only diffs.
-
-### Step 4: Write or Update the PR Title
-
-Write or re-evaluate the title before finalizing the body.
-
-Title format: `<type>(<scope>): <Subject>` or `<type>: <Subject>`.
-
-Allowed types: `feat`, `fix`, `ref`, `perf`, `docs`, `test`, `build`, `ci`, `chore`, `style`, `meta`, `license`, `revert`.
-
-Rules:
-- The dominant change, not the latest commit
-- The narrowest accurate type and scope
-- No bracketed labels like `[codex]`, `[claude]`, `[ai]`, `[bot]`, or `[wip]`
-- No agent, tool, or automation attribution
-- No vague process titles like `update`, `cleanup`, `misc`, `fix stuff`, or `address feedback`
-- No trailing period
-
-Rewrite invalid titles before creating or updating the PR:
-
-- `[codex] Paginate replay segment downloads` -> `fix(replay): Paginate recording segment downloads`
-
-Use this test on updates: if a reviewer read only the title, would they still form the right expectation about the current diff? If not, rewrite it.
-
-### Step 5: Write or Update the PR Description
-
-Write a reviewer-facing cover note, not a generated changelog.
-
-Default to 1-2 short paragraphs:
-
-```markdown
-<What changed and what effect it has.>
-
-<Why this approach, tradeoff, risk, or review focus matters, if it is not obvious from the diff.>
-```
-
-Write enough context that a reviewer can predict the shape and intent of the diff before opening it. The body should answer the questions that code alone will not: why the change exists, what behavior changes, what tradeoff was chosen, and what deserves careful review.
-
-Use structure only when the change needs it:
-
-| Change shape | Useful body shape |
-|--------------|-------------------|
-| Small obvious change | one concise paragraph; no headings |
-| Bug fix | problem/root cause/fix in prose; headings only if the body would be confusing without them |
-| API, schema, payload, config, permissions, or CLI change | before/after fenced blocks when direct comparison is clearer than prose |
-| Performance or reliability change | include measured impact or expected tradeoff when known; do not invent numbers |
-| Broad, generated, or cross-cutting change | explain the organizing principle and where reviewers should start |
-| Review feedback update | rewrite the whole body around the current final diff; do not append a progress log |
-
-Rules:
-- Lead with changed behavior or effect, then implementation detail only when useful.
-- Prefer paragraphs over headings and bullets.
-- Use bullets only to guide review order, list genuine alternatives/tradeoffs, or compare independent contract changes.
-- When verification matters, fold it into the relevant prose instead of adding a separate checklist.
-- Include issue references only when the exact ID or URL is present in user input, branch name, commits, or verified tracker output; omit the line entirely otherwise.
-- Keep links self-contained by summarizing the relevant context in the body.
-- Prefer synthesized reviewer context over file-by-file narration, copied commit logs, generic headings like "Summary" or "Changes", and stale template scaffolding.
-
-Hard constraints:
-- Customer data — customer/org names, user emails, support ticket contents, or PII. Describe the technical symptom, not who hit it, and use the Issue References syntax below only when a verified ticket is available. PRs are typically public on open-source repos.
-- Never invent issue references or leave placeholders like `XXXXX`, `<issue>`, or `TODO`.
-- Generate reviewer prose only. Do not add new agent trace links, "action taken on behalf" lines, or tool attribution. When refreshing an existing PR, preserve an existing integration-owned footer only if it appears intentional and the user did not ask to remove it.
-
-When updating, rewrite the body as one coherent description of the current PR.
-
-### Step 6: Create or Update the PR
-
-For a new PR, create a draft with the rewritten title and body:
+Create draft PR:
 
 ```bash
-gh pr create --draft --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+gh pr create --draft --title "<type>(<scope>): <subject>" --body "$(cat <<'EOF'
 <description body here>
 EOF
 )"
 ```
 
-Before running the create or update command, strip any issue reference not backed by known context. Never emit placeholder IDs (`XXXXX`, `<issue>`, `TODO`).
-
-For an existing PR, patch the title and body after you have re-evaluated both. If the current title still fits, keep it intentionally rather than skipping title review.
+Update existing PR:
 
 ```bash
 gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER \
@@ -161,101 +274,12 @@ EOF
 )"
 ```
 
-## PR Description Examples
-
-### Simple PR
-
-```markdown
-The AI Customizations section in the sessions sidebar now starts collapsed so
-it does not consume space before users need it. Expanding the section keeps the
-same persisted preference behavior as before.
-```
-
-### Feature PR
-
-```markdown
-Alert updates and resolves now reply to the original Slack message instead of
-creating a new channel message. This keeps the notification timeline grouped in
-one thread and reduces channel noise.
-```
-
-### Bug Fix PR
-
-```markdown
-Inactive authenticated users now go to account reactivation before the login
-view honors a `next` URL.
-
-The GET login path could previously bounce an inactive user between
-`/auth/login/` and a protected view because it redirected authenticated users
-without checking `is_active`. The POST path already handled this case, so this
-applies the same guard to the GET redirect and covers the loop with a regression
-test.
-```
-
-### Schema Change PR
-
-````markdown
-Run logs now write one versioned record per analyzed chunk instead of one
-large skill-level record. This lets `warden runs follow` show findings as
-chunks complete while preserving durable run reconstruction at finalization.
-
-Before, each line represented a full skill result:
-
-```jsonc
-{
-  "run": {...},
-  "skill": "security-review",
-  "summary": "Found 2 issues",
-  "findings": [...],
-  "files": [...]
-}
-```
-
-After, each line represents one chunk result:
-
-```jsonc
-{
-  "schemaVersion": 1,
-  "run": {...},
-  "skill": "security-review",
-  "chunk": {
-    "file": "src/api/auth.ts",
-    "index": 1,
-    "total": 2,
-    "lineRange": "42-45"
-  },
-  "status": "ok",
-  "findings": [...]
-}
-```
-
-````
-
-### Refactor PR
-
-````markdown
-Duplicate validation code from the alerts, issues, and projects endpoints now
-lives in a shared validator class without changing endpoint behavior.
-Future validation rules can now be added in one place instead of being copied
-across each endpoint.
-````
-
-### Broad Review PR
-
-```markdown
-The admin layout now holds together at narrow viewport widths: the shared
-header, details grid, result table, and sidebar wrap, collapse, or scroll
-instead of overflowing the viewport. The changes are intentionally limited to
-responsive layout behavior; table column prioritization is left out because it
-needs product judgment.
-
-Review the shared layout and table wrappers first, then check individual
-component breakpoints for regressions.
-```
+Use `gh api` for PR updates.
 
 ## Issue References
 
-Reference issues in the PR body:
+Use only when verified from user input, branch name, commits, PR comments, or
+tracker output.
 
 | Syntax | Effect |
 |--------|--------|
@@ -264,20 +288,15 @@ Reference issues in the PR body:
 | `Refs GH-1234` | Links without closing |
 | `Refs LINEAR-ABC-123` | Links Linear issue |
 
-These are syntax examples — do not copy example IDs into a real PR body.
+These are syntax examples. Do not copy example IDs into a real PR body.
 
-## Guidelines
+## Final Check
 
-- **One PR per feature/fix** - Don't bundle unrelated changes
-- **Keep PRs reviewable** - Smaller PRs get faster, better reviews
-- **Explain the why** - Code shows what; description explains why
-- **Mark WIP early** - Use draft PRs for early feedback
-- **Rewrite, don't append** - Updated PRs should read like a fresh description of the current diff
-- **Re-evaluate the title on updates** - Do not assume the existing title still fits after scope changes
-
-Note: `gh pr edit` is currently broken due to GitHub's Projects (classic) deprecation.
-
-## References
-
-- [Sentry Code Review Guidelines](https://develop.sentry.dev/engineering-practices/code-review/)
-- [Sentry Commit Messages](https://develop.sentry.dev/engineering-practices/commit-messages/)
+- Title matches the dominant full-branch change and uses `!` for breaking
+  changes.
+- Body length and structure match change size/risk.
+- Optional artifacts reduce reviewer effort.
+- Breaking changes name affected surface and migration/compatibility context.
+- Routine validation is omitted unless it changes reviewer risk assessment.
+- Issue references are verified or omitted.
+- Customer data, PII, tool attribution, and placeholders are absent.

--- a/skills/pr-writer/SPEC.md
+++ b/skills/pr-writer/SPEC.md
@@ -4,18 +4,21 @@
 
 The `pr-writer` skill creates and updates pull requests with concise, review-oriented titles and descriptions that match Sentry conventions.
 
-Its main job is to turn branch changes into a reviewer-facing cover note that explains what changed, why it changed, and the few details reviewers need before reading the diff. It should avoid long essays, mechanical diff summaries, fill-in-the-template prose, agent/tool attribution markers, and vague titles that no longer match the branch scope.
+Its main job is to turn branch changes into a reviewer-facing cover note that explains what changed, why it changed, and the few details reviewers need before reading the diff. The output should adapt to the size, risk, and shape of the change: simple PRs should stay terse, while broad, risky, breaking, API/schema, migration, generated, or workflow-heavy PRs should include only the extra structure that makes review easier.
+
+The skill should offer the agent a small menu of optional reviewer aids, such as before/after examples, schemas, interfaces, Mermaid diagrams, screenshots, rollout notes, migration notes, review order, or risk callouts. These are decision tools, not required sections. The agent should choose them with simple heuristics and its own judgment, then omit anything that does not materially improve reviewer understanding.
 
 ## Scope
 
 In scope:
 
 - Creating draft pull requests from committed feature branches.
-- Updating existing PRs by re-evaluating both title and body against the current diff.
+- Updating existing PRs by re-evaluating both title and body against the full branch diff against the base branch.
 - Producing natural PR bodies that default to short paragraphs and use structure only when the change shape needs it.
+- Choosing optional reviewer aids based on the actual diff shape, including code snippets, payload examples, schemas/interfaces, diagrams, screenshots, review-order notes, rollout notes, migration notes, or risk/tradeoff callouts.
 - Producing titles that accurately describe the dominant change in the PR.
 - Rejecting bracketed agent, bot, or tool prefixes in PR titles.
-- Including issue references and review context when useful.
+- Including issue references, breaking-change context, and review focus when useful and supported by known evidence.
 
 Out of scope:
 
@@ -23,6 +26,8 @@ Out of scope:
 - Running full CI or iterating on failing checks.
 - Producing release notes, changelogs, or customer-facing announcements.
 - Including mechanical test-plan checklists in PR bodies.
+- Mirroring repository PR templates, including empty headings, placeholder checklists, rote "Summary / Test Plan" sections, or validation logs that do not help reviewers understand the change.
+- Creating decorative diagrams, exhaustive file-by-file walkthroughs, or copied diffs that make the body longer without reducing reviewer effort.
 
 ## Users And Trigger Context
 
@@ -32,9 +37,12 @@ Out of scope:
 
 ## Runtime Contract
 
-- Required first actions: verify the current branch, committed state, base branch, and diff scope before writing or updating a PR; when updating, inspect the current PR title and body before deciding what to keep.
+- Required first actions: verify the current branch, committed state, base branch, and diff scope before writing or updating a PR; when updating, use the PR's `baseRefName` as the base branch and inspect the current PR title and body before deciding what to keep.
 - Required outputs: a conventional PR title and a concise, natural PR body suitable for `gh pr create` or GitHub API update commands; on updates, include an explicit keep-or-rewrite decision for the title.
+- Required body-shape decision: decide whether the change is small/obvious, bug fix, feature, refactor, API/schema/payload/config/CLI change, breaking change, migration, performance/reliability change, broad/generated/cross-cutting change, UI change, workflow/architecture change, or review-feedback update. Use the decision to select the minimum useful structure.
 - Required update behavior: if an open PR exists and follow-up commits materially change reviewer expectations, refresh the PR even when the user did not explicitly ask for a PR edit.
+- Optional reviewer aids: use before/after blocks for contract or behavior comparisons; schemas or interface snippets for API, payload, type, config, event, or storage changes; Mermaid sequence/flow/state diagrams for async flows, queues, state transitions, lifecycle changes, or multi-component interactions; screenshots or recordings for UI behavior; review-order notes for broad or generated PRs; rollout, migration, compatibility, feature-flag, or deprecation notes for changes that affect adopters or operations.
+- Hard negatives: do not add a `Test Plan` section by default, do not paste command transcripts, do not list routine validation as its own heading unless it changes risk assessment, do not add empty template headings, do not narrate every file, do not include Mermaid when prose is clearer, and do not include schemas or examples that merely duplicate obvious code.
 - Non-negotiable constraints: never include customer data or PII, never use bracketed agent/tool labels such as `[codex]` in PR titles, never invent issue references, generate reviewer prose rather than tool attribution, ignore repository PR templates, and prefer draft PRs for newly opened pull requests.
 - Expected bundled files loaded at runtime: only `SKILL.md`.
 
@@ -48,14 +56,22 @@ Authoritative sources:
 - Google Engineering Practices guidance for CL descriptions.
 - Git and Linux kernel patch submission guidance.
 - GitHub pull request reviewability guidance.
+- GitHub and GitLab Markdown support for Mermaid diagrams in PR/MR descriptions.
+- GitLab merge request template prior art for before/after visual comparisons and local validation only when useful.
+- Atlassian pull request guidance on using descriptions, reviewer navigation, and visuals to reduce reviewer reconstruction work.
+- Conventional Commits and changelog guidance for identifying and communicating breaking changes.
 - Observed user rejection of programmatic PR descriptions and preference for concise reviewer context.
 - `getsentry/warden#265` as a formatting exemplar for before/after examples on schema and output-shape changes, only when direct comparison is warranted.
 
 Useful improvement sources:
 
 - positive examples: PR descriptions that read like a human cover note and give reviewers the missing context.
+- positive examples: PR descriptions that use optional artifacts sparingly, such as a compact schema/interface, before/after payload, Mermaid flow, screenshot, rollout note, or review-order note when that artifact makes the diff easier to review.
+- positive examples: PR descriptions that use concrete behavior and reviewer impact instead of meta phrases like "decision model", "expanded contract", or "runtime guidance".
 - positive examples: PR titles that stay specific after follow-up commits.
 - negative examples: PR bodies that read like essays, repeat the diff, overuse headings, mirror a template, or leak internal agent process.
+- negative examples: PR bodies with rote `Test Plan` headings, pasted command output, generic validation details, decorative diagrams, oversized Mermaid blocks, unnecessary schemas, empty headings, or file-by-file narration.
+- negative examples: PR bodies that read like release notes for the prompt rather than a human cover note for the change.
 - negative examples: PR titles that are vague, process-oriented, or stale after scope changes.
 - negative examples: PR titles that use bracketed agent/tool labels instead of conventional commit types, such as `[codex] Paginate replay segment downloads`.
 - negative examples: branches with material follow-up commits where the agent pushed changes but left the PR title/body stale.
@@ -80,17 +96,20 @@ Data that must not be stored:
 
 ## Evaluation
 
-- Lightweight validation: compare generated titles and PR bodies against representative feature, bug-fix, schema-change, broad-review, and refactor prompts for brevity, clarity, justified structure, issue references, update-path title handling, and privacy handling.
+- Lightweight validation: compare generated titles and PR bodies against representative feature, bug-fix, schema-change, breaking-change, migration, UI, performance/reliability, broad-review, generated-change, workflow-diagram, and refactor prompts for brevity, clarity, justified structure, issue references, update-path title handling, and privacy handling.
 - Deeper evaluation: maintain a small prompt set with expected body shapes if regressions recur.
 - Holdout examples: include at least one simple PR that should be one paragraph, one bug fix that should explain root cause without file bullets, one PR with no known issue reference, and one API or input-format change that should use separate before/after fenced blocks.
-- Holdout examples: include at least one PR update where the old title no longer matches the final diff and must be rewritten.
+- Holdout examples: include at least one breaking contract change that should identify affected consumers and migration guidance, one workflow-heavy PR that should use a compact Mermaid diagram, one UI PR that should mention screenshots or visual evidence only if available, one broad generated PR that should explain generation/review order, and one small PR that must not grow a `Test Plan` or template headings.
+- Holdout examples: include at least one PR update where the old title no longer matches the whole PR diff and must be rewritten.
 - Holdout examples: include at least one review-feedback or follow-up-commit scenario where the skill should refresh an open PR without an explicit PR-update request.
-- Acceptance gates: output title uses an allowed Sentry conventional commit type, contains no bracketed agent/tool prefix, matches the dominant change, update flows explicitly re-evaluate whether the existing title still fits, material follow-up commits to an open PR trigger a refresh even without an explicit PR-update request, output reads like natural reviewer-facing prose, default body uses paragraphs instead of generic headings, structure is present only when justified by the change shape, before/after examples appear only when direct comparison is the clearest explanation, unknown issue references are omitted instead of invented, verification appears only as reviewer-relevant context, generated tool attribution is absent, and customer data is excluded.
+- Acceptance gates: output title uses an allowed Sentry conventional commit type, uses `!` when the dominant change is breaking, contains no bracketed agent/tool prefix, matches the dominant change, update flows explicitly re-evaluate whether the existing title still fits, material follow-up commits to an open PR trigger a refresh even without an explicit PR-update request, output reads like natural reviewer-facing prose, default body uses paragraphs instead of generic headings, structure is present only when justified by the change shape, optional artifacts are used only when they reduce reviewer effort, body language describes concrete behavior and reviewer impact instead of internal process, breaking changes include affected surface and migration/compatibility context when known, before/after examples appear only when direct comparison is the clearest explanation, unknown issue references are omitted instead of invented, routine validation is omitted unless it changes reviewer risk assessment or explains coverage for changed behavior, generated tool attribution is absent, and customer data is excluded.
 
 ## Known Limitations
 
 - The skill cannot guarantee that issue references are correct unless the branch, commits, or user provide them. It must omit references rather than invent placeholders.
 - It relies on the agent's judgment to decide when a heading, bullet list, or before/after block helps reviewers more than plain paragraphs.
+- It relies on the agent's judgment to decide whether optional reviewer aids, such as schemas, diagrams, screenshots, migration notes, or review-order notes, reduce reviewer effort enough to justify their length.
+- Mermaid rendering support and syntax differ by platform/version, so diagrams must stay simple and should be omitted when uncertain or not essential.
 - It relies on the agent's judgment to decide when a title is still accurate enough to keep versus rewrite.
 - Very large PRs may still need more context than the default body shape encourages.
 


### PR DESCRIPTION
The `pr-writer` skill now steers PR descriptions toward the full branch diff instead of the latest commit or a generated template. Small changes should stay short, while breaking changes, schema updates, generated diffs, and workflow changes get the extra context reviewers need.

Schemas, before/after examples, Mermaid diagrams, rollout notes, and review order are treated as optional reviewer aids, not default sections. Routine validation stays out of PR bodies unless it changes review risk.