### PR TITLE
feat(skills): Add migrate-container-queries skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,7 @@
       "Skill(sentry-skills:gh-review-requests)",
       "Skill(sentry-skills:gha-security-review)",
       "Skill(sentry-skills:iterate-pr)",
+      "Skill(sentry-skills:migrate-container-queries)",
       "Skill(sentry-skills:pr-link-issue)",
       "Skill(sentry-skills:pr-writer)",
       "Skill(sentry-skills:presentation-creator)",

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Works with Claude Code, Cursor, Cline, GitHub Copilot, and other compatible agen
 | [gh-review-requests](skills/gh-review-requests/SKILL.md) | Fetch unread GitHub notifications for open PRs where review is requested from a specified team or opened by a team member. |
 | [gha-security-review](skills/gha-security-review/SKILL.md) | GitHub Actions security review for workflow exploitation vulnerabilities. |
 | [iterate-pr](skills/iterate-pr/SKILL.md) | Iterate on a PR until CI passes and actionable review feedback is addressed. |
+| [migrate-container-queries](skills/migrate-container-queries/SKILL.md) | Migrate viewport media queries (@media, useMedia) to container queries in Sentry's frontend, refactoring to Container/Flex/Grid primitives where possible. |
 | [presentation-creator](skills/presentation-creator/SKILL.md) | Create data-driven presentation slides using React, Vite, and Recharts with Sentry branding. |
 | [pr-link-issue](skills/pr-link-issue/SKILL.md) | Append a GitHub issue link and its Linear ticket to the current PR's description. |
 | [pr-writer](skills/pr-writer/SKILL.md) | Create, refresh, and rewrite pull request titles and descriptions following Sentry conventions. |

--- a/skills/claude-settings-audit/SKILL.md
+++ b/skills/claude-settings-audit/SKILL.md
@@ -158,6 +158,7 @@ If this is a Sentry project (or sentry-skills plugin is installed), include:
   "Skill(sentry-skills:gh-review-requests)",
   "Skill(sentry-skills:gha-security-review)",
   "Skill(sentry-skills:iterate-pr)",
+  "Skill(sentry-skills:migrate-container-queries)",
   "Skill(sentry-skills:pr-link-issue)",
   "Skill(sentry-skills:pr-writer)",
   "Skill(sentry-skills:presentation-creator)",

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -38,7 +38,7 @@ Do not read these two tables across a row — the keys do not correspond.
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | 0px | 320px | 384px | 448px | 512px | 576px | 640px | 768px | 896px | 1024px | 1152px | 1280px |
 
-**Rule:** find the element's actual rendered width, then pick the `container` token whose pixel value is *nearest* to that width — never the token with the matching key. `breakpoints.sm` (800px) is nowhere near `container.sm` (512px). Confirm the choice with a visual check.
+**Rule:** take the old breakpoint's pixel value and pick the `container` token whose pixel value is *nearest* to it — never the token with the matching key. `breakpoints.sm` is 800px, so it maps to `container.xl` (768px), not `container.sm` (512px). Then confirm with a visual check: the container is often narrower than the viewport, so the nearest-px token is a starting point, not a guarantee.
 
 ## Genuine viewport width → `screen:` keys, not `useMedia`
 
@@ -51,14 +51,10 @@ Width — container or viewport — has a prop/hook path above. Leave `useMedia`
 
 ## container-type: only when no query container is in scope
 
-The app's main content is already wrapped in a query container: `ContentStack` (`#main`) in `views/organizationLayout/index.tsx` sets `containerType="inline-size"` and wraps the routed `<Outlet />`, so product views have a container ancestor. `topBar` has its own, and `#modal-portal` (in `styles/global.tsx`) covers portaled content that lives outside the app tree. **Do not add `container-type: inline-size` reflexively.**
-
-**Default: don't add one.** Bare responsive keys (`{xs: …}`) and `@container` queries already resolve against the nearest ancestor container. Add `container-type` only when this subtree must respond to *its own* width rather than the page's.
-
-When you do add one:
+**Default: don't add one.** Bare keys and `@container` already resolve against the nearest ancestor container, and product views have one: `ContentStack` (`#main`, `views/organizationLayout/index.tsx`) wraps the routed `<Outlet />` with `containerType="inline-size"`; `topBar` and `#modal-portal` cover their own subtrees. Add `container-type` only when a subtree must respond to *its own* width rather than the page's — then:
 
 - Use `inline-size` (width only). `size` also queries height, which collapses content unless height is set elsewhere.
-- For a reusable component that may or may not already sit inside a container, make it conditional so it doesn't create a redundant one — `containerType={hasParentQueryContainer ? 'normal' : 'inline-size'}` via `useHasContainerQuery()` (see `components/core/breadcrumbList/breadcrumbList.tsx`).
+- In a reusable component that may already sit inside a container, make it conditional to avoid a redundant one — `containerType={hasParentQueryContainer ? 'normal' : 'inline-size'}` via `useHasContainerQuery()` (see `components/core/breadcrumbList/breadcrumbList.tsx`).
 
 ## Examples
 
@@ -86,9 +82,9 @@ import {Flex} from '@sentry/scraps/layout';
 // Old
 @media (max-width: ${p => p.theme.breakpoints.md}) { ... }
 
-// New — swap at-rule AND scale; md breakpoint (992px) → nearest container by real width,
-// NOT theme.container.md by matching key
-@container (max-width: ${p => p.theme.container.sm}) { ... }
+// New — swap at-rule AND scale; md breakpoint (992px) → nearest container token by px
+// is 3xl (1024px), NOT theme.container.md by matching key
+@container (max-width: ${p => p.theme.container['3xl']}) { ... }
 ```
 
 ### Rung 3 — `useMedia` (width) → `useContainerBreakpoint()`
@@ -107,11 +103,10 @@ const isNarrow = breakpoint === 'zero';
 
 ## Migration Checklist
 
-- [ ] Rung 1: replace styled `@media` with `Container`/`Flex`/`Grid`/`Stack` responsive props
-- [ ] Rung 2 (CSS can't be a prop): `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*`
-- [ ] Choose the `container` token nearest the element's real width — never reuse the breakpoint key
-- [ ] Rung 3: width `useMedia` → `useContainerBreakpoint()`
-- [ ] Genuine viewport-width cases → `screen:` responsive keys (not `useMedia`); keep `useMedia` only for non-width media features
-- [ ] Add `container-type` only when a subtree must respond to its own width; prefer `inline-size`
-- [ ] Confirm a query-container ancestor exists so `@container` resolves (it silently no-ops otherwise)
-- [ ] **Visual check:** resize the element and confirm identical output flipping at the intended width
+Took the lowest rung that fits (above). Then verify the gotchas:
+
+- [ ] Chose the `container` token nearest the old breakpoint's pixel value — never reused the breakpoint key
+- [ ] Routed genuine viewport-width cases to `screen:` keys; kept `useMedia` only for non-width media features
+- [ ] Added `container-type` only when a subtree needs its own; used `inline-size`
+- [ ] Confirmed a query-container ancestor exists (`@container` silently no-ops without one)
+- [ ] **Visual check:** resized the element and confirmed identical output flipping at the intended width

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -5,7 +5,7 @@ description: Guide for migrating viewport media queries (@media, useMedia) to co
 
 # Container Query Migration Guide
 
-Migrate viewport-based responsive logic (`@media` + `useMedia`) to container queries so components respond to their own available space instead of the raw viewport. Reference migration: trace-view PR getsentry/sentry#120315.
+Migrate viewport-based responsive logic (`@media` + `useMedia`) to container queries so components respond to their own available space instead of the raw viewport.
 
 > **Always do a visual check.** After every migration, resize the *element* (not just the window) and confirm the layout is identical and flips at the intended width. The token scales differ, so a mechanical swap that compiles can still render wrong.
 
@@ -17,12 +17,12 @@ Stop at the first rung that fits. Prefer replacing hand-rolled CSS with primitiv
 |------|------|-----|
 | 1. Primitive props | The `@media` only flips layout (`flex-direction`, `display`, `grid-template`, gap, visibility, width) | Delete the styled component; use `Container`/`Flex`/`Grid`/`Stack` responsive props (`direction={{xs: 'column', md: 'row'}}`) |
 | 2. `@container` swap | CSS can't be a prop (descendant selectors, pseudo-elements, `font-size`, complex `grid-template-areas`) | Keep the styled component; swap `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*` |
-| 3. `useContainerBreakpoint()` | Width is read in JS to branch rendering | Replace `useMedia(...)` with `useContainerBreakpoint()` |
+| 3. `useResponsivePropValue()` | Width is read in JS to branch rendering | Replace `useMedia(...)` with `useResponsivePropValue({...})`; use `useContainerBreakpoint()` only when you need the raw active key |
 | 4. Leave as `useMedia` | Genuine media feature, not width | Do nothing — these do not migrate |
 
 ## ⚠️ Convert to the nearest container scale
 
-Breakpoint and container scales have **different keys and different pixel values** — this is not a rename. Reusing the same key is the #1 migration bug (the trace PR "compared a container measurement to the wrong scale").
+Breakpoint and container scales have **different keys and different pixel values** — this is not a rename. Reusing the same key is the #1 migration bug.
 
 | `theme.breakpoints` | | `theme.container` | |
 |---|---|---|---|
@@ -44,10 +44,12 @@ Width is the only thing that migrates. Leave `useMedia` in place for:
 
 The app's main content is already wrapped in a query container: `ContentStack` (`#main`) in `views/organizationLayout/index.tsx` sets `containerType="inline-size"` and wraps the routed `<Outlet />`, so product views have a container ancestor. `topBar` has its own, and `#modal-portal` (in `styles/global.tsx`) covers portaled content that lives outside the app tree. **Do not add `container-type: inline-size` reflexively.**
 
-- Bare responsive keys (`{xs: …}`) already resolve against the nearest container.
-- Add a container only when this subtree needs its own local one.
-- Prefer `inline-size` (width only); `size` also contains height and collapses content unless height comes from elsewhere.
-- Conditional pattern (see `components/core/breadcrumbList/breadcrumbList.tsx`): `containerType={hasParentQueryContainer ? 'normal' : 'inline-size'}` via `useHasContainerQuery()`.
+**Default: don't add one.** Bare responsive keys (`{xs: …}`) and `@container` queries already resolve against the nearest ancestor container. Add `container-type` only when this subtree must respond to *its own* width rather than the page's.
+
+When you do add one:
+
+- Use `inline-size` (width only). `size` also queries height, which collapses content unless height is set elsewhere.
+- For a reusable component that may or may not already sit inside a container, make it conditional so it doesn't create a redundant one — `containerType={hasParentQueryContainer ? 'normal' : 'inline-size'}` via `useHasContainerQuery()` (see `components/core/breadcrumbList/breadcrumbList.tsx`).
 
 ## Examples
 
@@ -80,16 +82,19 @@ import {Flex} from '@sentry/scraps/layout';
 @container (max-width: ${p => p.theme.container.sm}) { ... }
 ```
 
-### Rung 3 — `useMedia` (width) → `useContainerBreakpoint()`
+### Rung 3 — `useMedia` (width) → `useResponsivePropValue()`
 
 ```tsx
 // Old
 const isNarrow = useMedia(`(max-width: ${theme.breakpoints.sm})`);
 
-// New
+// New — resolve a per-breakpoint map against the current container (mirrors rung-1 props)
+import {useResponsivePropValue} from '@sentry/scraps/layout';
+const isNarrow = useResponsivePropValue({xs: true, sm: false});
+
+// Only when you need the raw active key itself (to log or pass along):
 import {useContainerBreakpoint} from '@sentry/scraps/layout';
 const breakpoint = useContainerBreakpoint(); // 'zero' | '3xs' | ... | 'xl'
-const isNarrow = ['zero', '3xs', '2xs', 'xs'].includes(breakpoint);
 ```
 
 ## Migration Checklist
@@ -97,7 +102,7 @@ const isNarrow = ['zero', '3xs', '2xs', 'xs'].includes(breakpoint);
 - [ ] Rung 1: replace styled `@media` with `Container`/`Flex`/`Grid`/`Stack` responsive props
 - [ ] Rung 2 (CSS can't be a prop): `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*`
 - [ ] Choose the `container` token nearest the element's real width — never reuse the breakpoint key
-- [ ] Rung 3: width `useMedia` → `useContainerBreakpoint()`; keep `useMedia` for non-width media features
-- [ ] Add `container-type` only if no query container is already in scope; prefer `inline-size`
+- [ ] Rung 3: width `useMedia` → `useResponsivePropValue({...})` (or `useContainerBreakpoint()` for the raw key); keep `useMedia` for non-width media features
+- [ ] Add `container-type` only when a subtree must respond to its own width; prefer `inline-size`
 - [ ] Confirm a query-container ancestor exists so `@container` resolves (it silently no-ops otherwise)
 - [ ] **Visual check:** resize the element and confirm identical output flipping at the intended width

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: migrate-container-queries
+description: Guide for migrating viewport media queries (@media, useMedia) to container queries in Sentry's frontend. Use when migrating responsive layout to container queries, replacing @media/useMedia, refactoring styled responsive components to Container/Flex/Grid primitives, or working on the DE container-query migration.
+---
+
+# Container Query Migration Guide
+
+Migrate viewport-based responsive logic (`@media` + `useMedia`) to container queries so components respond to their own available space instead of the raw viewport. Reference migration: trace-view PR getsentry/sentry#120315.
+
+## Approach: refactor first, swap second
+
+Work down this ladder — stop at the first rung that fits. Prefer replacing hand-rolled CSS with primitives over a mechanical token swap.
+
+| Rung | When | Do |
+|------|------|-----|
+| 1. Primitive props | The `@media` only flips layout (`flex-direction`, `display`, `grid-template`, gap, visibility, width) | Delete the styled component; use `Container`/`Flex`/`Grid`/`Stack` responsive props (`direction={{xs: 'column', md: 'row'}}`) |
+| 2. `@container` swap | CSS can't be a prop (descendant selectors, pseudo-elements, `font-size`, complex `grid-template-areas`) | Keep the styled component; swap `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*` |
+| 3. `useContainerBreakpoint()` | Width is read in JS to branch rendering | Replace `useMedia(...)` with `useContainerBreakpoint()` |
+| 4. Leave as `useMedia` | Genuine media feature, not width (see below) | Do nothing — these do not migrate |
+
+## ⚠️ Breakpoints and container scales are NOT the same
+
+The token scales have **different keys and different pixel values**. This is not a rename.
+
+| `theme.breakpoints` | | `theme.container` | |
+|---|---|---|---|
+| `2xs` | 0px | `zero` | 0px |
+| `xs` | 500px | `3xs` | 320px |
+| `sm` | 800px | `2xs` | 384px |
+| `md` | 992px | `xs` | 448px |
+| `lg` | 1200px | `sm` | 512px |
+| `xl` | 1440px | `md` | 576px |
+
+Pick the `container` token that matches the element's **actual rendered width**, not the same key. `breakpoints.sm` (800px) is nowhere near `container.sm` (512px). Getting this wrong is the #1 migration bug — the trace PR's original code "compared a container measurement to the wrong (breakpoint) scale."
+
+## container-type: only when no query container is in scope
+
+A root query container is already declared in `styles/global.tsx`, and app layout containers (`organizationLayout`, `topBar`, modal portal) provide others. **Do not add `container-type: inline-size` reflexively.**
+
+- Bare responsive keys (`{xs: …}`) already resolve against the nearest container.
+- Add a container only when this subtree needs its own local one.
+- Prefer `inline-size` (width only); `size` also contains height and collapses content unless height comes from elsewhere.
+- Conditional pattern (see `components/core/breadcrumbList/breadcrumbList.tsx`): `containerType={hasParentQueryContainer ? 'normal' : 'inline-size'}` via `useHasContainerQuery()`.
+
+## Keep `useMedia` for genuine media features
+
+Width is the only thing that migrates. Leave `useMedia` in place for:
+
+`prefers-color-scheme`, `prefers-reduced-motion`, `hover`, `pointer`, `max-height` / height-based, `resolution`, `print`.
+
+## Examples
+
+### Rung 1 — styled `@media` → primitive props (preferred)
+
+**Old:**
+
+```tsx
+const Row = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${p => p.theme.space.md};
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    flex-direction: column;
+  }
+`;
+```
+
+**New** — delete the styled component:
+
+```tsx
+import {Flex} from '@sentry/scraps/layout';
+
+<Flex direction={{xs: 'column', sm: 'row'}} gap="md">
+```
+
+### Rung 2 — `@media` → `@container` (when it can't be a prop)
+
+**Old:**
+
+```tsx
+const Panel = styled('section')`
+  @media (max-width: ${p => p.theme.breakpoints.md}) {
+    grid-template-columns: 1fr;
+  }
+`;
+```
+
+**New** — swap the at-rule and the scale (md breakpoint 992px ≈ container `sm`/`md`, choose by real width):
+
+```tsx
+const Panel = styled('section')`
+  @container (max-width: ${p => p.theme.container.sm}) {
+    grid-template-columns: 1fr;
+  }
+`;
+```
+
+### Rung 3 — `useMedia` (width) → `useContainerBreakpoint()`
+
+**Old:**
+
+```tsx
+const isNarrow = useMedia(`(max-width: ${theme.breakpoints.sm})`);
+return isNarrow ? <Stacked /> : <SideBySide />;
+```
+
+**New:**
+
+```tsx
+import {useContainerBreakpoint} from '@sentry/scraps/layout';
+
+const breakpoint = useContainerBreakpoint(); // active container key: 'zero' | '3xs' | ... | 'xl'
+const isNarrow = ['zero', '3xs', '2xs', 'xs'].includes(breakpoint);
+```
+
+### Anti-pattern — blind key rename
+
+```tsx
+// ❌ Same key, wrong pixel value — sm breakpoint (800px) ≠ sm container (512px)
+@container (max-width: ${p => p.theme.container.sm}) // was breakpoints.sm
+
+// ✅ Choose the container token matching the element's real width; verify in the browser
+```
+
+## Verify
+
+- `@container` silently no-ops if there is no query-container ancestor — confirm one exists (root, layout, or a local `containerType`).
+- Resize the element (not just the window) and confirm the breakpoint flips at the intended width.
+- Visual output must be identical; the DOM/CSS diff may be larger (a deleted styled component is the intended outcome, not scope creep).
+
+## Migration Checklist
+
+- [ ] Prefer rung 1: replace styled `@media` with `Container`/`Flex`/`Grid`/`Stack` responsive props
+- [ ] Rung 2 only when CSS can't be a prop: `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*`
+- [ ] Choose the `container` token by real width — do NOT reuse the breakpoint key
+- [ ] Replace width `useMedia` → `useContainerBreakpoint()`; keep `useMedia` for non-width media features
+- [ ] Add `container-type` only if no query container is already in scope; prefer `inline-size`
+- [ ] Confirm a query-container ancestor exists so `@container` resolves
+- [ ] Verify visually identical output by resizing the element

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -7,20 +7,22 @@ description: Guide for migrating viewport media queries (@media, useMedia) to co
 
 Migrate viewport-based responsive logic (`@media` + `useMedia`) to container queries so components respond to their own available space instead of the raw viewport. Reference migration: trace-view PR getsentry/sentry#120315.
 
+> **Always do a visual check.** After every migration, resize the *element* (not just the window) and confirm the layout is identical and flips at the intended width. The token scales differ, so a mechanical swap that compiles can still render wrong.
+
 ## Approach: refactor first, swap second
 
-Work down this ladder — stop at the first rung that fits. Prefer replacing hand-rolled CSS with primitives over a mechanical token swap.
+Stop at the first rung that fits. Prefer replacing hand-rolled CSS with primitives over a mechanical token swap.
 
 | Rung | When | Do |
 |------|------|-----|
 | 1. Primitive props | The `@media` only flips layout (`flex-direction`, `display`, `grid-template`, gap, visibility, width) | Delete the styled component; use `Container`/`Flex`/`Grid`/`Stack` responsive props (`direction={{xs: 'column', md: 'row'}}`) |
 | 2. `@container` swap | CSS can't be a prop (descendant selectors, pseudo-elements, `font-size`, complex `grid-template-areas`) | Keep the styled component; swap `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*` |
 | 3. `useContainerBreakpoint()` | Width is read in JS to branch rendering | Replace `useMedia(...)` with `useContainerBreakpoint()` |
-| 4. Leave as `useMedia` | Genuine media feature, not width (see below) | Do nothing — these do not migrate |
+| 4. Leave as `useMedia` | Genuine media feature, not width | Do nothing — these do not migrate |
 
-## ⚠️ Breakpoints and container scales are NOT the same
+## ⚠️ Convert to the nearest container scale
 
-The token scales have **different keys and different pixel values**. This is not a rename.
+Breakpoint and container scales have **different keys and different pixel values** — this is not a rename. Reusing the same key is the #1 migration bug (the trace PR "compared a container measurement to the wrong scale").
 
 | `theme.breakpoints` | | `theme.container` | |
 |---|---|---|---|
@@ -31,30 +33,28 @@ The token scales have **different keys and different pixel values**. This is not
 | `lg` | 1200px | `sm` | 512px |
 | `xl` | 1440px | `md` | 576px |
 
-Pick the `container` token that matches the element's **actual rendered width**, not the same key. `breakpoints.sm` (800px) is nowhere near `container.sm` (512px). Getting this wrong is the #1 migration bug — the trace PR's original code "compared a container measurement to the wrong (breakpoint) scale."
+**Rule:** find the element's actual rendered width, then pick the `container` token whose pixel value is *nearest* to that width — never the token with the matching key. `breakpoints.sm` (800px) is nowhere near `container.sm` (512px). Confirm the choice with a visual check.
+
+## Keep `useMedia` for genuine media features
+
+Width is the only thing that migrates. Leave `useMedia` in place for:
+`prefers-color-scheme`, `prefers-reduced-motion`, `hover`, `pointer`, `max-height` / height-based, `resolution`, `print`.
 
 ## container-type: only when no query container is in scope
 
-A root query container is already declared in `styles/global.tsx`, and app layout containers (`organizationLayout`, `topBar`, modal portal) provide others. **Do not add `container-type: inline-size` reflexively.**
+A root query container is declared in `styles/global.tsx`, and app layout containers (`organizationLayout`, `topBar`, modal portal) provide others. **Do not add `container-type: inline-size` reflexively.**
 
 - Bare responsive keys (`{xs: …}`) already resolve against the nearest container.
 - Add a container only when this subtree needs its own local one.
 - Prefer `inline-size` (width only); `size` also contains height and collapses content unless height comes from elsewhere.
 - Conditional pattern (see `components/core/breadcrumbList/breadcrumbList.tsx`): `containerType={hasParentQueryContainer ? 'normal' : 'inline-size'}` via `useHasContainerQuery()`.
 
-## Keep `useMedia` for genuine media features
-
-Width is the only thing that migrates. Leave `useMedia` in place for:
-
-`prefers-color-scheme`, `prefers-reduced-motion`, `hover`, `pointer`, `max-height` / height-based, `resolution`, `print`.
-
 ## Examples
 
 ### Rung 1 — styled `@media` → primitive props (preferred)
 
-**Old:**
-
 ```tsx
+// Old — delete the styled component
 const Row = styled('div')`
   display: flex;
   flex-direction: row;
@@ -63,77 +63,41 @@ const Row = styled('div')`
     flex-direction: column;
   }
 `;
-```
 
-**New** — delete the styled component:
-
-```tsx
+// New
 import {Flex} from '@sentry/scraps/layout';
-
 <Flex direction={{xs: 'column', sm: 'row'}} gap="md">
 ```
 
 ### Rung 2 — `@media` → `@container` (when it can't be a prop)
 
-**Old:**
-
 ```tsx
-const Panel = styled('section')`
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: 1fr;
-  }
-`;
-```
+// Old
+@media (max-width: ${p => p.theme.breakpoints.md}) { ... }
 
-**New** — swap the at-rule and the scale (md breakpoint 992px ≈ container `sm`/`md`, choose by real width):
-
-```tsx
-const Panel = styled('section')`
-  @container (max-width: ${p => p.theme.container.sm}) {
-    grid-template-columns: 1fr;
-  }
-`;
+// New — swap at-rule AND scale; md breakpoint (992px) → nearest container by real width,
+// NOT theme.container.md by matching key
+@container (max-width: ${p => p.theme.container.sm}) { ... }
 ```
 
 ### Rung 3 — `useMedia` (width) → `useContainerBreakpoint()`
 
-**Old:**
-
 ```tsx
+// Old
 const isNarrow = useMedia(`(max-width: ${theme.breakpoints.sm})`);
-return isNarrow ? <Stacked /> : <SideBySide />;
-```
 
-**New:**
-
-```tsx
+// New
 import {useContainerBreakpoint} from '@sentry/scraps/layout';
-
-const breakpoint = useContainerBreakpoint(); // active container key: 'zero' | '3xs' | ... | 'xl'
+const breakpoint = useContainerBreakpoint(); // 'zero' | '3xs' | ... | 'xl'
 const isNarrow = ['zero', '3xs', '2xs', 'xs'].includes(breakpoint);
 ```
 
-### Anti-pattern — blind key rename
-
-```tsx
-// ❌ Same key, wrong pixel value — sm breakpoint (800px) ≠ sm container (512px)
-@container (max-width: ${p => p.theme.container.sm}) // was breakpoints.sm
-
-// ✅ Choose the container token matching the element's real width; verify in the browser
-```
-
-## Verify
-
-- `@container` silently no-ops if there is no query-container ancestor — confirm one exists (root, layout, or a local `containerType`).
-- Resize the element (not just the window) and confirm the breakpoint flips at the intended width.
-- Visual output must be identical; the DOM/CSS diff may be larger (a deleted styled component is the intended outcome, not scope creep).
-
 ## Migration Checklist
 
-- [ ] Prefer rung 1: replace styled `@media` with `Container`/`Flex`/`Grid`/`Stack` responsive props
-- [ ] Rung 2 only when CSS can't be a prop: `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*`
-- [ ] Choose the `container` token by real width — do NOT reuse the breakpoint key
-- [ ] Replace width `useMedia` → `useContainerBreakpoint()`; keep `useMedia` for non-width media features
+- [ ] Rung 1: replace styled `@media` with `Container`/`Flex`/`Grid`/`Stack` responsive props
+- [ ] Rung 2 (CSS can't be a prop): `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*`
+- [ ] Choose the `container` token nearest the element's real width — never reuse the breakpoint key
+- [ ] Rung 3: width `useMedia` → `useContainerBreakpoint()`; keep `useMedia` for non-width media features
 - [ ] Add `container-type` only if no query container is already in scope; prefer `inline-size`
-- [ ] Confirm a query-container ancestor exists so `@container` resolves
-- [ ] Verify visually identical output by resizing the element
+- [ ] Confirm a query-container ancestor exists so `@container` resolves (it silently no-ops otherwise)
+- [ ] **Visual check:** resize the element and confirm identical output flipping at the intended width

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -103,7 +103,7 @@ const isNarrow = breakpoint === 'zero';
 
 Took the lowest rung that fits (above). Then verify the gotchas:
 
-- [ ] Mapped by pixel value, not by name — e.g. `breakpoints.sm` → `container.xl`, not `container.sm`
+- [ ] Mapped to the `container` token with the nearest pixel value, not the same name — e.g. `breakpoints.sm` → `container.xl`, not `container.sm`
 - [ ] Routed genuine viewport-width cases to `screen:` keys; kept `useMedia` only for non-width media features
 - [ ] Added `container-type` only when a subtree needs its own; used `inline-size`
 - [ ] Confirmed a query-container ancestor exists (`@container` silently no-ops without one)

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -36,7 +36,7 @@ Breakpoint and container scales have **different keys and different pixel values
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | 0px | 320px | 384px | 448px | 512px | 576px | 640px | 768px | 896px | 1024px | 1152px | 1280px |
 
-**Rule:** take the old breakpoint's pixel value and pick the `container` token whose pixel value is *nearest* to it — never the token with the matching key. `breakpoints.sm` is 800px, so it maps to `container.xl` (768px), not `container.sm` (512px). Then confirm with a visual check: the container is often narrower than the viewport, so the nearest-px token is a starting point, not a guarantee.
+**Rule:** take the old breakpoint's pixel value and pick the `container` token whose pixel value is *nearest* to it — not the token with the same name. `breakpoints.sm` is 800px, so it maps to `container.xl` (768px), not `container.sm` (512px). Then confirm with a visual check: the container is often narrower than the viewport, so the nearest-px token is a starting point, not a guarantee.
 
 ## Genuine viewport width → `screen:` keys, not `useMedia`
 
@@ -103,7 +103,7 @@ const isNarrow = breakpoint === 'zero';
 
 Took the lowest rung that fits (above). Then verify the gotchas:
 
-- [ ] Chose the `container` token nearest the old breakpoint's pixel value — never reused the breakpoint key
+- [ ] Mapped by pixel value, not by name — e.g. `breakpoints.sm` → `container.xl`, not `container.sm`
 - [ ] Routed genuine viewport-width cases to `screen:` keys; kept `useMedia` only for non-width media features
 - [ ] Added `container-type` only when a subtree needs its own; used `inline-size`
 - [ ] Confirmed a query-container ancestor exists (`@container` silently no-ops without one)

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -42,7 +42,7 @@ Width is the only thing that migrates. Leave `useMedia` in place for:
 
 ## container-type: only when no query container is in scope
 
-A root query container is declared in `styles/global.tsx`, and app layout containers (`organizationLayout`, `topBar`, modal portal) provide others. **Do not add `container-type: inline-size` reflexively.**
+The app's main content is already wrapped in a query container: `ContentStack` (`#main`) in `views/organizationLayout/index.tsx` sets `containerType="inline-size"` and wraps the routed `<Outlet />`, so product views have a container ancestor. `topBar` has its own, and `#modal-portal` (in `styles/global.tsx`) covers portaled content that lives outside the app tree. **Do not add `container-type: inline-size` reflexively.**
 
 - Bare responsive keys (`{xs: …}`) already resolve against the nearest container.
 - Add a container only when this subtree needs its own local one.

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -7,7 +7,7 @@ description: Guide for migrating viewport media queries (@media, useMedia) to co
 
 Migrate viewport-based responsive logic (`@media` + `useMedia`) to container queries so components respond to their own available space instead of the raw viewport.
 
-> **Always do a visual check.** After every migration, resize the *element* (not just the window) and confirm the layout is identical and flips at the intended width. The token scales differ, so a mechanical swap that compiles can still render wrong.
+> **Always do a visual check.** After every migration, resize the *element* (not just the window) and confirm the layout is identical and flips at the intended width. A good way to narrow an element without touching the window is to open a resizable panel next to it — e.g. drag out the Seer explorer sidebar, which squeezes the middle content. The token scales differ, so a mechanical swap that compiles can still render wrong.
 
 ## Approach: refactor first, swap second
 
@@ -17,27 +17,36 @@ Stop at the first rung that fits. Prefer replacing hand-rolled CSS with primitiv
 |------|------|-----|
 | 1. Primitive props | The `@media` only flips layout (`flex-direction`, `display`, `grid-template`, gap, visibility, width) | Delete the styled component; use `Container`/`Flex`/`Grid`/`Stack` responsive props (`direction={{xs: 'column', md: 'row'}}`) |
 | 2. `@container` swap | CSS can't be a prop (descendant selectors, pseudo-elements, `font-size`, complex `grid-template-areas`) | Keep the styled component; swap `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*` |
-| 3. `useResponsivePropValue()` | Width is read in JS to branch rendering | Replace `useMedia(...)` with `useResponsivePropValue({...})`; use `useContainerBreakpoint()` only when you need the raw active key |
+| 3. `useContainerBreakpoint()` | Width is read in JS to branch rendering | Replace `useMedia(...)` with `useContainerBreakpoint()` — the container-scoped `useMedia` |
 | 4. Leave as `useMedia` | Genuine media feature, not width | Do nothing — these do not migrate |
 
 ## ⚠️ Convert to the nearest container scale
 
 Breakpoint and container scales have **different keys and different pixel values** — this is not a rename. Reusing the same key is the #1 migration bug.
 
-| `theme.breakpoints` | | `theme.container` | |
-|---|---|---|---|
-| `2xs` | 0px | `zero` | 0px |
-| `xs` | 500px | `3xs` | 320px |
-| `sm` | 800px | `2xs` | 384px |
-| `md` | 992px | `xs` | 448px |
-| `lg` | 1200px | `sm` | 512px |
-| `xl` | 1440px | `md` | 576px |
+Do not read these two tables across a row — the keys do not correspond.
+
+`theme.breakpoints` (viewport / `@media`), base `2xs`:
+
+| `2xs` | `xs` | `sm` | `md` | `lg` | `xl` | `2xl` |
+|---|---|---|---|---|---|---|
+| 0px | 500px | 800px | 992px | 1200px | 1440px | 2560px |
+
+`theme.container` (container / `@container`), base `zero`:
+
+| `zero` | `3xs` | `2xs` | `xs` | `sm` | `md` | `lg` | `xl` | `2xl` | `3xl` | `4xl` | `5xl` |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| 0px | 320px | 384px | 448px | 512px | 576px | 640px | 768px | 896px | 1024px | 1152px | 1280px |
 
 **Rule:** find the element's actual rendered width, then pick the `container` token whose pixel value is *nearest* to that width — never the token with the matching key. `breakpoints.sm` (800px) is nowhere near `container.sm` (512px). Confirm the choice with a visual check.
 
-## Keep `useMedia` for genuine media features
+## Genuine viewport width → `screen:` keys, not `useMedia`
 
-Width is the only thing that migrates. Leave `useMedia` in place for:
+When layout truly must follow the *window* (not the component's room), don't keep `useMedia` — use a `screen:`-prefixed responsive prop, which resolves against the viewport on the `theme.breakpoints` scale: `direction={{zero: 'column', 'screen:lg': 'row'}}`. Bare keys and `screen:` keys can mix on one prop. Prefer bare (container) keys; reach for `screen:` only when the viewport genuinely drives the layout.
+
+## Keep `useMedia` only for non-width media features
+
+Width — container or viewport — has a prop/hook path above. Leave `useMedia` in place only for:
 `prefers-color-scheme`, `prefers-reduced-motion`, `hover`, `pointer`, `max-height` / height-based, `resolution`, `print`.
 
 ## container-type: only when no query container is in scope
@@ -82,19 +91,18 @@ import {Flex} from '@sentry/scraps/layout';
 @container (max-width: ${p => p.theme.container.sm}) { ... }
 ```
 
-### Rung 3 — `useMedia` (width) → `useResponsivePropValue()`
+### Rung 3 — `useMedia` (width) → `useContainerBreakpoint()`
+
+`useContainerBreakpoint()` is the container-scoped replacement for width-based `useMedia`. Call it from a descendant of a query container; it returns the container's active breakpoint on the container scale (`zero` … `5xl`) and updates as the container crosses a breakpoint.
 
 ```tsx
 // Old
 const isNarrow = useMedia(`(max-width: ${theme.breakpoints.sm})`);
 
-// New — resolve a per-breakpoint map against the current container (mirrors rung-1 props)
-import {useResponsivePropValue} from '@sentry/scraps/layout';
-const isNarrow = useResponsivePropValue({xs: true, sm: false});
-
-// Only when you need the raw active key itself (to log or pass along):
+// New — reads the container's active breakpoint, not the viewport
 import {useContainerBreakpoint} from '@sentry/scraps/layout';
-const breakpoint = useContainerBreakpoint(); // 'zero' | '3xs' | ... | 'xl'
+const breakpoint = useContainerBreakpoint(); // 'zero' | '3xs' | ... | '5xl'
+const isNarrow = breakpoint === 'zero';
 ```
 
 ## Migration Checklist
@@ -102,7 +110,8 @@ const breakpoint = useContainerBreakpoint(); // 'zero' | '3xs' | ... | 'xl'
 - [ ] Rung 1: replace styled `@media` with `Container`/`Flex`/`Grid`/`Stack` responsive props
 - [ ] Rung 2 (CSS can't be a prop): `@media` → `@container`, `theme.breakpoints.*` → `theme.container.*`
 - [ ] Choose the `container` token nearest the element's real width — never reuse the breakpoint key
-- [ ] Rung 3: width `useMedia` → `useResponsivePropValue({...})` (or `useContainerBreakpoint()` for the raw key); keep `useMedia` for non-width media features
+- [ ] Rung 3: width `useMedia` → `useContainerBreakpoint()`
+- [ ] Genuine viewport-width cases → `screen:` responsive keys (not `useMedia`); keep `useMedia` only for non-width media features
 - [ ] Add `container-type` only when a subtree must respond to its own width; prefer `inline-size`
 - [ ] Confirm a query-container ancestor exists so `@container` resolves (it silently no-ops otherwise)
 - [ ] **Visual check:** resize the element and confirm identical output flipping at the intended width

--- a/skills/migrate-container-queries/SKILL.md
+++ b/skills/migrate-container-queries/SKILL.md
@@ -22,9 +22,7 @@ Stop at the first rung that fits. Prefer replacing hand-rolled CSS with primitiv
 
 ## ⚠️ Convert to the nearest container scale
 
-Breakpoint and container scales have **different keys and different pixel values** — this is not a rename. Reusing the same key is the #1 migration bug.
-
-Do not read these two tables across a row — the keys do not correspond.
+Breakpoint and container scales have **different keys and different pixel values** — this is not a rename. **MAP BY PIXEL VALUE, NOT BY KEY:** `breakpoints.sm` does NOT become `container.sm`. Reusing the same key is the #1 migration bug.
 
 `theme.breakpoints` (viewport / `@media`), base `2xs`:
 

--- a/skills/migrate-container-queries/SPEC.md
+++ b/skills/migrate-container-queries/SPEC.md
@@ -2,7 +2,7 @@
 
 ## Intent
 
-Give Sentry frontend engineers a reliable, low-risk path for converting viewport-based responsive logic (`@media`, `useMedia`) to container queries, so components respond to their own available width instead of the raw viewport. The dominant failure mode this skill guards against is mapping a breakpoint token to the container token of the same name: the two scales share names but not pixel values.
+Provide a reliable, low-risk path for converting viewport-based responsive logic (`@media`, `useMedia`) to container queries, so components respond to their own available width instead of the raw viewport. The dominant failure mode this skill guards against is mapping a breakpoint token to the container token of the same name: the two scales share names but not pixel values.
 
 ## Scope
 

--- a/skills/migrate-container-queries/SPEC.md
+++ b/skills/migrate-container-queries/SPEC.md
@@ -1,0 +1,69 @@
+# Container Query Migration Guide Specification
+
+## Intent
+
+Give Sentry frontend engineers a reliable, low-risk path for converting viewport-based responsive logic (`@media`, `useMedia`) to container queries, so components respond to their own available width instead of the raw viewport. The dominant failure mode this skill guards against is reusing a breakpoint key as a container key: the two scales share names but not pixel values.
+
+## Scope
+
+In scope:
+- Migrating `@media` CSS and `useMedia` width checks to container-query equivalents.
+- Choosing between primitive layout props, `@container` CSS, and `useContainerBreakpoint()`.
+- Mapping a breakpoint width to the *nearest* container token by pixel value.
+- Deciding when to add `container-type`.
+
+Out of scope:
+- Non-width media features (`prefers-*`, `hover`, `pointer`, `resolution`, height-based, `print`) — these stay on `useMedia`.
+- Building the container-query primitives or theme tokens themselves.
+- General responsive-design guidance unrelated to the container-query migration.
+
+## Users And Trigger Context
+
+- Primary users: Sentry frontend engineers working the DE container-query migration.
+- Common user requests: "migrate this to container queries", "replace `@media`/`useMedia`", "refactor these styled responsive components to primitives".
+- Should not trigger for: non-width media-feature work, or new responsive code that is not a migration.
+
+## Runtime Contract
+
+- Required first actions: identify the lowest rung that fits (primitive prop → `@container` → `useContainerBreakpoint()` → leave as `useMedia`).
+- Required outputs: migrated code plus a nearest-scale token choice justified by the element's real rendered width.
+- Non-negotiable constraints:
+  - Convert to the container token *nearest* the element's real width; never reuse the breakpoint key.
+  - Always perform a visual check by resizing the element after migrating.
+  - Keep `useMedia` for genuine (non-width) media features.
+- Expected bundled files loaded at runtime: `SKILL.md` only.
+
+## Source And Evidence Model
+
+Authoritative sources:
+- Reference migration PR getsentry/sentry#120315 (trace-view).
+- Sentry theme token definitions (`theme.breakpoints`, `theme.container`).
+- `components/core/breadcrumbList/breadcrumbList.tsx` (conditional `container-type` pattern).
+
+Useful improvement sources:
+- positive examples: merged migration PRs that pass visual review.
+- negative examples: PRs that mismatched breakpoint/container scales.
+- issue or PR feedback: reviewer comments on wrong-scale or missing-container-ancestor bugs.
+
+Data that must not be stored: secrets, customer data, private URLs or identifiers not needed for reproduction.
+
+## Reference Architecture
+
+- `SKILL.md` contains: the full runtime guide (rung ladder, scale table + nearest-scale rule, examples, checklist).
+- `references/` contains: nothing yet; add only if a rung needs depth beyond the inline guide.
+
+## Validation
+
+- Lightweight validation: `uv run scripts/quick_validate.py skills/migrate-container-queries`.
+- Deeper validation: manual visual check by resizing the migrated element.
+- Acceptance gates: token choice is the nearest container scale by pixel value; a query-container ancestor exists; output is visually identical.
+
+## Known Limitations
+
+- The breakpoint→container mapping requires knowing the element's real rendered width, which the skill cannot measure for the agent — the engineer must confirm it in the browser.
+- `@container` silently no-ops without a query-container ancestor; the skill flags this but cannot detect it statically.
+
+## Maintenance Notes
+
+- Update `SKILL.md` when the token scales change, primitives gain/lose props, or a new rung is needed.
+- Update `SPEC.md` when intent, scope, the non-negotiable constraints, or the evidence model change.

--- a/skills/migrate-container-queries/SPEC.md
+++ b/skills/migrate-container-queries/SPEC.md
@@ -27,11 +27,11 @@ Out of scope:
 ## Runtime Contract
 
 - Required first actions: identify the lowest rung that fits (primitive prop → `@container` → `useContainerBreakpoint()` → leave as `useMedia`).
-- Required outputs: migrated code plus a nearest-scale token choice justified by the element's real rendered width.
+- Required outputs: migrated code plus a token choice mapped from the old breakpoint's pixel value to the nearest `container` token.
 - Non-negotiable constraints:
-  - Convert to the container token *nearest* the element's real width; never reuse the breakpoint key.
-  - Always perform a visual check by resizing the element after migrating.
-  - Keep `useMedia` for genuine (non-width) media features.
+  - Convert to the container token *nearest* the old breakpoint's pixel value; never reuse the breakpoint key.
+  - Always perform a visual check by resizing the element after migrating (the container is often narrower than the viewport).
+  - Route genuine viewport-width cases to `screen:` keys; keep `useMedia` only for non-width media features.
 - Expected bundled files loaded at runtime: `SKILL.md` only.
 
 ## Source And Evidence Model
@@ -62,7 +62,7 @@ Data that must not be stored: secrets, customer data, private URLs or identifier
 
 ## Known Limitations
 
-- The breakpoint→container mapping requires knowing the element's real rendered width, which the skill cannot measure for the agent — the engineer must confirm it in the browser.
+- The nearest-px token is only a starting point: the container is often narrower than the viewport, so the true reflow width needs a browser visual check the skill cannot perform.
 - `@container` silently no-ops without a query-container ancestor; the skill flags this but cannot detect it statically.
 
 ## Maintenance Notes

--- a/skills/migrate-container-queries/SPEC.md
+++ b/skills/migrate-container-queries/SPEC.md
@@ -2,70 +2,32 @@
 
 ## Intent
 
-Give Sentry frontend engineers a reliable, low-risk path for converting viewport-based responsive logic (`@media`, `useMedia`) to container queries, so components respond to their own available width instead of the raw viewport. The dominant failure mode this skill guards against is reusing a breakpoint key as a container key: the two scales share names but not pixel values.
+Give Sentry frontend engineers a reliable, low-risk path for converting viewport-based responsive logic (`@media`, `useMedia`) to container queries, so components respond to their own available width instead of the raw viewport. The dominant failure mode this skill guards against is mapping a breakpoint token to the container token of the same name: the two scales share names but not pixel values.
 
 ## Scope
 
-In scope:
-- Migrating `@media` CSS and `useMedia` width checks to container-query equivalents.
-- Choosing between primitive layout props, `@container` CSS, and the `useContainerBreakpoint()` JS width hook.
-- Mapping a breakpoint width to the *nearest* container token by pixel value.
-- Deciding when to add `container-type`.
-- Routing genuine viewport-width cases to `screen:` responsive keys rather than `useMedia`.
+In scope: migrating `@media`/`useMedia` width logic to primitive props, `@container` CSS, `useContainerBreakpoint()`, or `screen:` keys, and deciding when to add `container-type`.
 
-Out of scope:
-- Non-width media features (`prefers-*`, `hover`, `pointer`, `resolution`, height-based, `print`) — these stay on `useMedia`.
-- Building the container-query primitives or theme tokens themselves.
-- General responsive-design guidance unrelated to the container-query migration.
+Out of scope: non-width media features (`prefers-*`, `hover`, `pointer`, `resolution`, height-based, `print`) stay on `useMedia`; building the primitives or tokens themselves.
 
-## Users And Trigger Context
+## Non-negotiable Constraints
 
-- Primary users: Sentry frontend engineers working the DE container-query migration.
-- Common user requests: "migrate this to container queries", "replace `@media`/`useMedia`", "refactor these styled responsive components to primitives".
-- Should not trigger for: non-width media-feature work, or new responsive code that is not a migration.
+- Map to the `container` token with the pixel value *nearest* the old breakpoint's — never the same-named token.
+- Always visually verify by resizing the element (the container is often narrower than the viewport, so the nearest-px token is a starting point).
+- Route genuine viewport-width cases to `screen:` keys; keep `useMedia` only for non-width media features.
 
-## Runtime Contract
+## Sources
 
-- Required first actions: identify the lowest rung that fits (primitive prop → `@container` → `useContainerBreakpoint()` → leave as `useMedia`).
-- Required outputs: migrated code plus a token choice mapped from the old breakpoint's pixel value to the nearest `container` token.
-- Non-negotiable constraints:
-  - Convert to the container token *nearest* the old breakpoint's pixel value; never reuse the breakpoint key.
-  - Always perform a visual check by resizing the element after migrating (the container is often narrower than the viewport).
-  - Route genuine viewport-width cases to `screen:` keys; keep `useMedia` only for non-width media features.
-- Expected bundled files loaded at runtime: `SKILL.md` only.
-
-## Source And Evidence Model
-
-Authoritative sources:
-- Scraps `Container` story, "Container Queries" section (container vs. `screen:` keys, both token scales, `useContainerBreakpoint`, `container-type` guidance).
+- Scraps `Container` story, "Container Queries" section — authoritative for container vs. `screen:` keys, both token scales, `useContainerBreakpoint`, and `container-type` guidance.
 - Reference migration PR getsentry/sentry#120315 (trace-view).
-- Sentry theme token definitions (`theme.breakpoints`, `theme.container`).
-- `components/core/breadcrumbList/breadcrumbList.tsx` (conditional `container-type` pattern).
-
-Useful improvement sources:
-- positive examples: merged migration PRs that pass visual review.
-- negative examples: PRs that mismatched breakpoint/container scales.
-- issue or PR feedback: reviewer comments on wrong-scale or missing-container-ancestor bugs.
-
-Data that must not be stored: secrets, customer data, private URLs or identifiers not needed for reproduction.
-
-## Reference Architecture
-
-- `SKILL.md` contains: the full runtime guide (rung ladder, scale table + nearest-scale rule, examples, checklist).
-- `references/` contains: nothing yet; add only if a rung needs depth beyond the inline guide.
-
-## Validation
-
-- Lightweight validation: `uv run scripts/quick_validate.py skills/migrate-container-queries`.
-- Deeper validation: manual visual check by resizing the migrated element.
-- Acceptance gates: token choice is the nearest container scale by pixel value; a query-container ancestor exists; output is visually identical.
+- `components/core/breadcrumbList/breadcrumbList.tsx` — conditional `container-type` pattern.
 
 ## Known Limitations
 
-- The nearest-px token is only a starting point: the container is often narrower than the viewport, so the true reflow width needs a browser visual check the skill cannot perform.
+- The nearest-px token is only a starting point; the true reflow width needs a browser visual check the skill cannot perform.
 - `@container` silently no-ops without a query-container ancestor; the skill flags this but cannot detect it statically.
 
-## Maintenance Notes
+## Maintenance
 
-- Update `SKILL.md` when the token scales change, primitives gain/lose props, or a new rung is needed.
-- Update `SPEC.md` when intent, scope, the non-negotiable constraints, or the evidence model change.
+- Update `SKILL.md` when token scales change, primitives gain/lose props, or a rung is added.
+- Update `SPEC.md` when intent, scope, the non-negotiable constraints, or the sources change.

--- a/skills/migrate-container-queries/SPEC.md
+++ b/skills/migrate-container-queries/SPEC.md
@@ -8,9 +8,10 @@ Give Sentry frontend engineers a reliable, low-risk path for converting viewport
 
 In scope:
 - Migrating `@media` CSS and `useMedia` width checks to container-query equivalents.
-- Choosing between primitive layout props, `@container` CSS, and the JS width hooks (`useResponsivePropValue`, `useContainerBreakpoint`).
+- Choosing between primitive layout props, `@container` CSS, and the `useContainerBreakpoint()` JS width hook.
 - Mapping a breakpoint width to the *nearest* container token by pixel value.
 - Deciding when to add `container-type`.
+- Routing genuine viewport-width cases to `screen:` responsive keys rather than `useMedia`.
 
 Out of scope:
 - Non-width media features (`prefers-*`, `hover`, `pointer`, `resolution`, height-based, `print`) — these stay on `useMedia`.
@@ -25,7 +26,7 @@ Out of scope:
 
 ## Runtime Contract
 
-- Required first actions: identify the lowest rung that fits (primitive prop → `@container` → `useResponsivePropValue()` → leave as `useMedia`).
+- Required first actions: identify the lowest rung that fits (primitive prop → `@container` → `useContainerBreakpoint()` → leave as `useMedia`).
 - Required outputs: migrated code plus a nearest-scale token choice justified by the element's real rendered width.
 - Non-negotiable constraints:
   - Convert to the container token *nearest* the element's real width; never reuse the breakpoint key.
@@ -36,6 +37,7 @@ Out of scope:
 ## Source And Evidence Model
 
 Authoritative sources:
+- Scraps `Container` story, "Container Queries" section (container vs. `screen:` keys, both token scales, `useContainerBreakpoint`, `container-type` guidance).
 - Reference migration PR getsentry/sentry#120315 (trace-view).
 - Sentry theme token definitions (`theme.breakpoints`, `theme.container`).
 - `components/core/breadcrumbList/breadcrumbList.tsx` (conditional `container-type` pattern).

--- a/skills/migrate-container-queries/SPEC.md
+++ b/skills/migrate-container-queries/SPEC.md
@@ -8,7 +8,7 @@ Give Sentry frontend engineers a reliable, low-risk path for converting viewport
 
 In scope:
 - Migrating `@media` CSS and `useMedia` width checks to container-query equivalents.
-- Choosing between primitive layout props, `@container` CSS, and `useContainerBreakpoint()`.
+- Choosing between primitive layout props, `@container` CSS, and the JS width hooks (`useResponsivePropValue`, `useContainerBreakpoint`).
 - Mapping a breakpoint width to the *nearest* container token by pixel value.
 - Deciding when to add `container-type`.
 
@@ -25,7 +25,7 @@ Out of scope:
 
 ## Runtime Contract
 
-- Required first actions: identify the lowest rung that fits (primitive prop → `@container` → `useContainerBreakpoint()` → leave as `useMedia`).
+- Required first actions: identify the lowest rung that fits (primitive prop → `@container` → `useResponsivePropValue()` → leave as `useMedia`).
 - Required outputs: migrated code plus a nearest-scale token choice justified by the element's real rendered width.
 - Non-negotiable constraints:
   - Convert to the container token *nearest* the element's real width; never reuse the breakpoint key.


### PR DESCRIPTION
Adds the `migrate-container-queries` skill guiding the migration of viewport media queries (`@media`, `useMedia`) to container queries in Sentry's frontend, backing the Design Engineering [container-query migration project](https://linear.app/getsentry/project/migrate-media-queries-to-container-queries-c759b0f52fae) (DE-1368). It's a single inline `SKILL.md` plus a `SPEC.md` maintenance contract.